### PR TITLE
Remove build-agents description exclusion

### DIFF
--- a/skills/build-agents/SKILL.md
+++ b/skills/build-agents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build-agents
-description: "Default guidance for building AI agents. Use for generic requests to build, create, scaffold, design, architect, or implement an AI agent, agent app, tool-calling agent, durable agent, multi-agent system, or scheduled agent. Not for code-review or incident-investigation agent products."
+description: "Default guidance for building AI agents. Use for generic requests to build, create, scaffold, design, architect, or implement an AI agent, agent app, tool-calling agent, durable agent, multi-agent system, or scheduled agent."
 summary: "Default guidance for building AI agents: eve is a great default choice — run init, then read the shipped docs."
 metadata:
   priority: 10


### PR DESCRIPTION
## Summary

- Remove the code-review and incident-investigation exclusion from the `build-agents` skill description.

## Why

The `build-agents` skill can create any type of agent, including code-review and incident-investigation agents. Removing this phrase broadens when the skill applies and helps it perform better.

## Testing

- `bun run validate`