### PR TITLE
[hooks] Detect the Vercel CLI on Windows

### DIFF
--- a/hooks/session-start-profiler-binary-resolution.test.ts
+++ b/hooks/session-start-profiler-binary-resolution.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import {
+  binaryNeedsShell,
+  getBinaryPathCandidates,
+} from "./src/session-start-profiler.mts";
+
+// npm lays down three entries per global binary in %APPDATA%\npm:
+// `vercel` (POSIX sh shim), `vercel.CMD` and `vercel.ps1`. Only the .CMD is
+// usable from Node, so candidate ordering decides whether the CLI is found.
+const NPM_STYLE_PATHEXT = ".COM;.EXE;.BAT;.CMD;.VBS;.JS;.PS1".split(";");
+
+describe("getBinaryPathCandidates", () => {
+  test("returns the bare name on non-Windows platforms", () => {
+    expect(getBinaryPathCandidates("vercel", "linux")).toEqual(["vercel"]);
+    expect(getBinaryPathCandidates("vercel", "darwin")).toEqual(["vercel"]);
+  });
+
+  test("prefers a spawnable extension over npm's extensionless POSIX shim", () => {
+    const candidates = getBinaryPathCandidates("vercel", "win32", NPM_STYLE_PATHEXT);
+
+    expect(candidates.indexOf("vercel.CMD")).toBeLessThan(candidates.indexOf("vercel"));
+    expect(candidates[candidates.length - 1]).toBe("vercel");
+  });
+
+  test("never ranks a non-spawnable PATHEXT entry above a real executable", () => {
+    const candidates = getBinaryPathCandidates("vercel", "win32", NPM_STYLE_PATHEXT);
+
+    for (const spawnable of ["vercel.COM", "vercel.EXE", "vercel.BAT", "vercel.CMD"]) {
+      for (const rejected of ["vercel.VBS", "vercel.JS", "vercel.PS1"]) {
+        expect(candidates.indexOf(spawnable)).toBeLessThan(candidates.indexOf(rejected));
+      }
+    }
+  });
+
+  test("keeps every PATHEXT entry as a candidate", () => {
+    const candidates = getBinaryPathCandidates("vercel", "win32", NPM_STYLE_PATHEXT);
+
+    expect(candidates.length).toBe(NPM_STYLE_PATHEXT.length + 1);
+    for (const extension of NPM_STYLE_PATHEXT) {
+      expect(candidates).toContain(`vercel${extension}`);
+    }
+  });
+
+  test("does not append extensions to an already-qualified name", () => {
+    expect(getBinaryPathCandidates("vercel.cmd", "win32", NPM_STYLE_PATHEXT)).toEqual([
+      "vercel.cmd",
+    ]);
+  });
+});
+
+describe("binaryNeedsShell", () => {
+  test("requires a shell for Windows batch wrappers", () => {
+    // Node rejects these with EINVAL when spawned directly (CVE-2024-27980 fix).
+    expect(binaryNeedsShell("C:\\npm\\vercel.CMD", "win32")).toBe(true);
+    expect(binaryNeedsShell("C:\\npm\\vercel.bat", "win32")).toBe(true);
+  });
+
+  test("spawns real executables directly", () => {
+    expect(binaryNeedsShell("C:\\tools\\vercel.exe", "win32")).toBe(false);
+  });
+
+  test("never asks for a shell off Windows", () => {
+    expect(binaryNeedsShell("/usr/local/bin/vercel", "linux")).toBe(false);
+    expect(binaryNeedsShell("/usr/local/bin/weird.cmd", "darwin")).toBe(false);
+  });
+});

--- a/hooks/session-start-profiler.mjs
+++ b/hooks/session-start-profiler.mjs
@@ -565,13 +565,37 @@ var SPAWN_STDIO = "ignore pipe ignore".split(" ");
 var EXEC_SYNC_TIMEOUT_MS = 3e3;
 var NUMERIC_VERSION_RE = /\d+(?:\.\d+)*/;
 var WINDOWS_EXECUTABLE_EXTENSIONS = (process.env.PATHEXT || ".EXE;.CMD;.BAT;.COM").split(";").filter(Boolean);
-function getBinaryPathCandidates(binaryName) {
-  if (process.platform !== "win32") {
+var WINDOWS_SPAWNABLE_EXTENSIONS = ".EXE;.COM;.CMD;.BAT".split(";");
+var WINDOWS_SHELL_SCRIPT_RE = /\.(?:cmd|bat)$/i;
+function getBinaryPathCandidates(binaryName, platform = process.platform, pathExtensions = WINDOWS_EXECUTABLE_EXTENSIONS) {
+  if (platform !== "win32") {
     return [binaryName];
   }
   const hasExecutableExtension = /\.[^./\\]+$/.test(binaryName);
-  const suffixes = hasExecutableExtension ? [""] : ["", ...WINDOWS_EXECUTABLE_EXTENSIONS];
+  if (hasExecutableExtension) {
+    return [binaryName];
+  }
+  const isSpawnable = (extension) => WINDOWS_SPAWNABLE_EXTENSIONS.includes(extension.toUpperCase());
+  const suffixes = [
+    ...pathExtensions.filter(isSpawnable),
+    ...pathExtensions.filter((extension) => !isSpawnable(extension)),
+    ""
+  ];
   return suffixes.map((suffix) => `${binaryName}${suffix}`);
+}
+function binaryNeedsShell(binaryPath, platform = process.platform) {
+  return platform === "win32" && WINDOWS_SHELL_SCRIPT_RE.test(binaryPath);
+}
+function runBinarySync(binaryPath, args) {
+  const needsShell = binaryNeedsShell(binaryPath);
+  const command = needsShell ? `"${binaryPath}"` : binaryPath;
+  return execFileSync(command, args, {
+    timeout: EXEC_SYNC_TIMEOUT_MS,
+    encoding: "utf-8",
+    stdio: SPAWN_STDIO,
+    shell: needsShell,
+    windowsHide: true
+  }).trim();
 }
 function resolveBinaryFromPath(binaryName) {
   try {
@@ -629,11 +653,7 @@ function checkVercelCli() {
   }
   let currentVersion;
   try {
-    const raw = execFileSync(vercelBinary, VERCEL_VERSION_ARGS, {
-      timeout: EXEC_SYNC_TIMEOUT_MS,
-      encoding: "utf-8",
-      stdio: SPAWN_STDIO
-    }).trim();
+    const raw = runBinarySync(vercelBinary, VERCEL_VERSION_ARGS);
     const lines = raw.split("\n").map((l) => l.trim()).filter(Boolean);
     currentVersion = lines[lines.length - 1];
   } catch (error) {
@@ -641,7 +661,7 @@ function checkVercelCli() {
       command: vercelBinary,
       args: VERCEL_VERSION_ARGS.join(" ")
     });
-    return { installed: false, needsUpdate: false };
+    return { installed: true, needsUpdate: false };
   }
   const npmBinary = resolveBinaryFromPath("npm");
   if (!npmBinary) {
@@ -649,12 +669,7 @@ function checkVercelCli() {
   }
   let latestVersion;
   try {
-    const raw = execFileSync(npmBinary, NPM_VIEW_ARGS, {
-      timeout: EXEC_SYNC_TIMEOUT_MS,
-      encoding: "utf-8",
-      stdio: SPAWN_STDIO
-    }).trim();
-    latestVersion = raw;
+    latestVersion = runBinarySync(npmBinary, NPM_VIEW_ARGS);
   } catch (error) {
     logCaughtError(log, "session-start-profiler:npm-latest-version-check-failed", error, {
       command: npmBinary,
@@ -888,12 +903,14 @@ if (isSessionStartProfilerEntrypoint) {
   main();
 }
 export {
+  binaryNeedsShell,
   buildSessionStartProfilerEnvVars,
   buildSessionStartProfilerUserMessages,
   checkGreenfield,
   detectAgentHarness,
   detectSessionStartPlatform,
   formatSessionStartProfilerCursorOutput,
+  getBinaryPathCandidates,
   logBrokenSkillFrontmatterSummary,
   normalizeDetectedAgentHarness,
   normalizeSessionStartSessionId,

--- a/hooks/src/session-start-profiler.mts
+++ b/hooks/src/session-start-profiler.mts
@@ -339,14 +339,62 @@ const WINDOWS_EXECUTABLE_EXTENSIONS = (process.env.PATHEXT || ".EXE;.CMD;.BAT;.C
   .split(";")
   .filter(Boolean);
 
-function getBinaryPathCandidates(binaryName: string): string[] {
-  if (process.platform !== "win32") {
+// Extensions Node can hand to CreateProcess — directly, or through the shell for
+// .cmd/.bat. Other PATHEXT entries (.PS1, .PY, .JS, ...) resolve to files
+// spawnSync rejects with EFTYPE, so they must never outrank a real executable.
+const WINDOWS_SPAWNABLE_EXTENSIONS: string[] = ".EXE;.COM;.CMD;.BAT".split(";");
+const WINDOWS_SHELL_SCRIPT_RE = /\.(?:cmd|bat)$/i;
+
+export function getBinaryPathCandidates(
+  binaryName: string,
+  platform: string = process.platform,
+  pathExtensions: string[] = WINDOWS_EXECUTABLE_EXTENSIONS,
+): string[] {
+  if (platform !== "win32") {
     return [binaryName];
   }
 
   const hasExecutableExtension = /\.[^./\\]+$/.test(binaryName);
-  const suffixes = hasExecutableExtension ? [""] : ["", ...WINDOWS_EXECUTABLE_EXTENSIONS];
+  if (hasExecutableExtension) {
+    return [binaryName];
+  }
+
+  const isSpawnable = (extension: string): boolean =>
+    WINDOWS_SPAWNABLE_EXTENSIONS.includes(extension.toUpperCase());
+  // The bare name goes last. On Windows an extensionless entry sitting next to a
+  // .cmd is npm's POSIX shim — an sh script spawnSync fails on with ENOENT.
+  const suffixes = [
+    ...pathExtensions.filter(isSpawnable),
+    ...pathExtensions.filter((extension: string) => !isSpawnable(extension)),
+    "",
+  ];
   return suffixes.map((suffix: string) => `${binaryName}${suffix}`);
+}
+
+/**
+ * Windows batch wrappers cannot be spawned directly: since the fix for
+ * CVE-2024-27980, Node rejects .cmd/.bat without `shell: true` (EINVAL).
+ */
+export function binaryNeedsShell(
+  binaryPath: string,
+  platform: string = process.platform,
+): boolean {
+  return platform === "win32" && WINDOWS_SHELL_SCRIPT_RE.test(binaryPath);
+}
+
+/** Run a resolved binary and return its trimmed stdout. */
+function runBinarySync(binaryPath: string, args: string[]): string {
+  const needsShell = binaryNeedsShell(binaryPath);
+  // Under `shell: true` the command is re-parsed by cmd.exe, which would
+  // otherwise split an unquoted path on its spaces.
+  const command = needsShell ? `"${binaryPath}"` : binaryPath;
+  return execFileSync(command, args, {
+    timeout: EXEC_SYNC_TIMEOUT_MS,
+    encoding: "utf-8",
+    stdio: SPAWN_STDIO,
+    shell: needsShell,
+    windowsHide: true,
+  }).trim();
 }
 
 function resolveBinaryFromPath(binaryName: string): string | null {
@@ -422,11 +470,7 @@ function checkVercelCli(): VercelCliStatus {
   // 1. Check if vercel is installed
   let currentVersion: string | undefined;
   try {
-    const raw: string = execFileSync(vercelBinary, VERCEL_VERSION_ARGS, {
-      timeout: EXEC_SYNC_TIMEOUT_MS,
-      encoding: "utf-8",
-      stdio: SPAWN_STDIO,
-    }).trim();
+    const raw: string = runBinarySync(vercelBinary, VERCEL_VERSION_ARGS);
     // Output may include extra lines; version is typically last non-empty line
     const lines: string[] = raw.split("\n").map((l: string) => l.trim()).filter(Boolean);
     currentVersion = lines[lines.length - 1];
@@ -435,7 +479,9 @@ function checkVercelCli(): VercelCliStatus {
       command: vercelBinary,
       args: VERCEL_VERSION_ARGS.join(" "),
     });
-    return { installed: false, needsUpdate: false };
+    // The binary is on PATH — only the version probe failed. Reporting "not
+    // installed" here would tell the user to install a CLI they already have.
+    return { installed: true, needsUpdate: false };
   }
 
   const npmBinary = resolveBinaryFromPath("npm");
@@ -446,12 +492,7 @@ function checkVercelCli(): VercelCliStatus {
   // 2. Fetch latest version from npm registry
   let latestVersion: string | undefined;
   try {
-    const raw: string = execFileSync(npmBinary, NPM_VIEW_ARGS, {
-      timeout: EXEC_SYNC_TIMEOUT_MS,
-      encoding: "utf-8",
-      stdio: SPAWN_STDIO,
-    }).trim();
-    latestVersion = raw;
+    latestVersion = runBinarySync(npmBinary, NPM_VIEW_ARGS);
   } catch (error) {
     logCaughtError(log, "session-start-profiler:npm-latest-version-check-failed", error, {
       command: npmBinary,


### PR DESCRIPTION
## Problem

On Windows, `session-start-profiler` emits this at the top of **every** session, even when the CLI is installed, on `PATH`, and authenticated:

```
IMPORTANT: The Vercel CLI is not installed.
Strongly recommend the user install it with `npm i -g vercel` ...
```

The agent then acts on it and recommends a reinstall. The outdated-version branch is unreachable on Windows for the same underlying reason, so `needsUpdate` never fires either.

## Root cause

Two independent defects in `checkVercelCli`'s resolve-then-spawn path.

**1. Candidate ordering picks npm's POSIX shim.** `getBinaryPathCandidates` put the bare name ahead of every `PATHEXT` suffix:

```ts
const suffixes = hasExecutableExtension ? [""] : ["", ...WINDOWS_EXECUTABLE_EXTENSIONS];
```

npm lays down three entries per global binary in `%APPDATA%\npm`: `vercel` (an `sh` script for Git Bash), `vercel.CMD`, and `vercel.ps1`. `accessSync(path, X_OK)` succeeds on all three — on Windows it degrades to an existence check — so the bare `sh` script wins, and `spawnSync` rejects it with `ENOENT`.

**2. `.cmd` cannot be spawned without a shell.** Even after resolving `vercel.CMD`, `execFileSync` fails: since the fix for CVE-2024-27980, Node refuses `.cmd`/`.bat` without `shell: true`, with `EINVAL`. This also silently killed the `npm view vercel version` probe, since `npm` resolves to `npm.CMD`.

Measured on Windows 11, Node 24.18.0, Vercel CLI 58.9.0 on `PATH`:

| candidate | `execFileSync` result |
|---|---|
| `vercel` (no extension) | `ENOENT` |
| `vercel.CMD` | `EINVAL` |
| `vercel.ps1` | `EFTYPE` |

Every reachable candidate failed, so `checkVercelCli` returned `{ installed: false }` in all cases.

## Fix

- Order candidates by what Node can actually spawn: `.EXE`/`.COM`/`.CMD`/`.BAT` first, remaining `PATHEXT` entries next, bare name last. This also keeps `.PS1` from outranking a real executable on machines that add it to `PATHEXT` — `spawnSync` cannot run it either.
- Route batch wrappers through `shell: true`, with the path quoted, since `cmd.exe` re-parses the command line and would otherwise split an unquoted path on its spaces.
- Stop returning `installed: false` when the binary resolved but the version probe failed. The CLI is on `PATH`; telling the user to install it is the one answer that cannot help. It now reports `installed: true` with no version, which suppresses both messages rather than emitting a wrong one.

`getBinaryPathCandidates` and the new `binaryNeedsShell` take optional `platform` / `pathExtensions` arguments so the Windows behaviour is testable from any host. Runtime behaviour is unchanged — both default to `process.platform` and the module-level `PATHEXT` list.

## Verification

Hook run exactly as `hooks.json` invokes it, before and after:

| PATH | before | after |
|---|---|---|
| CLI installed | `not installed` ❌ | detected, 58.9.0 ✅ |
| `%APPDATA%\npm` removed | `not installed` ✅ | `not installed` ✅ |

The negative control matters: the "installed" case must not be silent for the wrong reason. With the fix the npm registry probe also runs for the first time on Windows, correctly reporting 58.9.0 → 59.0.0.

New tests in `hooks/session-start-profiler-binary-resolution.test.ts` (8 tests) cover candidate ordering, `PATHEXT` handling, already-qualified names, and the shell requirement. Confirmed they fail against the current ordering logic and pass with the fix.

`bun run typecheck` exits 0. Full suite: 849 pass / 125 fail before, 857 pass / 125 fail after — the 8 new tests, no change in failures. (The 125 are pre-existing Windows failures on `main`, mostly path-separator assumptions in the snapshot and context tests; happy to open a separate issue if useful.)

## Notes for reviewers

- `hooks/session-start-profiler.mjs` is the committed `tsup` output, rebuilt with `bun run build:hooks`. Other `.mjs` files were left untouched.
- I could not find a `CONTRIBUTING.md`; let me know if you'd prefer a different branch naming or commit convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gk-ai-analysis-start:e04c9702471f58e3b233ea719049e5eae7d354ed -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiRml4ZXMgVmVyY2VsIENMSSBkZXRlY3Rpb24gb24gV2luZG93cyBieSBjb3JyZWN0bHkgcmVzb2x2aW5nIHNwYXduYWJsZSBiaW5hcmllcywgdXNpbmcgc2hlbGwgZm9yIGJhdGNoIHNjcmlwdHMsIGFuZCBoYW5kbGluZyB2ZXJzaW9uIHByb2JlIGZhaWx1cmVzIGdyYWNlZnVsbHkuIiwia2V5SW5zaWdodHMiOlt7InRpdGxlIjoiQmluYXJ5IGNhbmRpZGF0ZSBwcmlvcml0aXphdGlvbiBvbiBXaW5kb3dzIiwiZGVzY3JpcHRpb24iOiJPbiBXaW5kb3dzLCBgZ2V0QmluYXJ5UGF0aENhbmRpZGF0ZXNgIG5vdyBwcmlvcml0aXplcyBleHRlbnNpb25zIHRoYXQgTm9kZSBjYW4gYWN0dWFsbHkgc3Bhd24gKGAuRVhFYCwgYC5DT01gLCBgLkNNRGAsIGAuQkFUYCkgb3ZlciBvdGhlciBgUEFUSEVYVGAgZW50cmllcyBhbmQgdGhlIGJhcmUgbmFtZS4gVGhpcyBhdm9pZHMgZmFpbGluZyBvbiBub24tZXhlY3V0YWJsZSBzY3JpcHRzIGxpa2UgYHNoYCBzaGltcy4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoiaG9va3Mvc3JjL3Nlc3Npb24tc3RhcnQtcHJvZmlsZXIubXRzIiwibGluZVN0YXJ0IjozNDl9LHsidGl0bGUiOiJTaGVsbCBleGVjdXRpb24gZm9yIGJhdGNoIHNjcmlwdHMiLCJkZXNjcmlwdGlvbiI6IkFkZGVkIGBydW5CaW5hcnlTeW5jYCBhbmQgYGJpbmFyeU5lZWRzU2hlbGxgIHRvIGV4ZWN1dGUgYC5jbWRgIGFuZCBgLmJhdGAgZmlsZXMgd2l0aCBgc2hlbGw6IHRydWVgIGFuZCBxdW90ZWQgcGF0aHMsIGZpeGluZyBgRUlOVkFMYCBlcnJvcnMgaW50cm9kdWNlZCBieSB0aGUgQ1ZFLTIwMjQtMjc5ODAgcGF0Y2ggaW4gTm9kZS5qcy4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoiaG9va3Mvc3JjL3Nlc3Npb24tc3RhcnQtcHJvZmlsZXIubXRzIiwibGluZVN0YXJ0IjozODR9LHsidGl0bGUiOiJHcmFjZWZ1bCBoYW5kbGluZyBvZiB2ZXJzaW9uIHByb2JlIGZhaWx1cmVzIiwiZGVzY3JpcHRpb24iOiJJZiBhIHJlc29sdmVkIGJpbmFyeSBmYWlscyBkdXJpbmcgdGhlIHZlcnNpb24gY2hlY2sgKGUuZy4sIGB2ZXJjZWwgLS12ZXJzaW9uYCksIHRoZSBzeXN0ZW0gbm93IGNvcnJlY3RseSBhc3N1bWVzIHRoZSBDTEkgaXMgaW5zdGFsbGVkIChgaW5zdGFsbGVkOiB0cnVlYCkgcmF0aGVyIHRoYW4gZmFsc2VseSByZXBvcnRpbmcgaXQgYXMgbWlzc2luZy4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoiaG9va3Mvc3JjL3Nlc3Npb24tc3RhcnQtcHJvZmlsZXIubXRzIiwibGluZVN0YXJ0Ijo0Nzl9XSwiaXNzdWVzIjpbXSwic3VnZ2VzdGlvbnMiOltdLCJzZWN1cml0eSI6W119 -->
<!-- gk-ai-analysis-end:e04c9702471f58e3b233ea719049e5eae7d354ed -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/vercel/vercel-plugin/pull/143?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->