### PR TITLE
[Plugin] adding install id to the active-session marker

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "Build and deploy web apps and agents",
   "author": {
     "name": "Vercel",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "Build and deploy web apps and agents",
   "author": {
     "name": "Vercel",

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel-plugin",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "Comprehensive Vercel ecosystem plugin — relational knowledge graph, skills for every major product, specialized agents, and Vercel conventions. Turns any AI agent into a Vercel expert.",
   "keywords": [
     "vercel",

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel-plugin",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "Comprehensive Vercel ecosystem plugin — relational knowledge graph, skills for every major product, specialized agents, and Vercel conventions. Turns any AI agent into a Vercel expert.",
   "author": {
     "name": "Vercel",

--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ How it is tracked:
   - `dau-stamp` prevents sending `dau:active_today` more than once per UTC day.
   - `harness-stamp-<harness>` prevents sending the same `plugin:agent_harness` value more than once per UTC day.
   - `first-use-stamp` prevents sending `plugin:first_use` more than once.
-  - `installation-id` stores the random installation UUID. It is used only by plugin telemetry and is not written to `active-session.json`.
+  - `installation-id` stores the random installation UUID.
 - Stamp files are written only after the telemetry bridge returns a successful response, so failed sends can retry later.
-- `active-session.json` is refreshed on session start with the plugin version and expiry timestamp. It lets Vercel CLI telemetry identify commands run while a recent Vercel plugin session marker is present. It contains no prompt text, file paths, project names, account IDs, tool-call contents, or skill-injection details.
+- `active-session.json` is refreshed on session start with the plugin version, the installation UUID, and an expiry timestamp. It lets Vercel CLI telemetry identify commands run while a recent Vercel plugin session marker is present, and attribute them to the same installation the plugin reports. It contains no prompt text, file paths, project names, account IDs, tool-call contents, or skill-injection details.
 
 Behavior:
 

--- a/hooks/src/telemetry.mts
+++ b/hooks/src/telemetry.mts
@@ -7,7 +7,7 @@ declare const __VERCEL_PLUGIN_VERSION__: string;
 
 const BRIDGE_ENDPOINT = "https://telemetry.vercel.com/api/vercel-plugin/v1/events";
 const FLUSH_TIMEOUT_MS = 3_000;
-export const PLUGIN_VERSION = typeof __VERCEL_PLUGIN_VERSION__ === "string" ? __VERCEL_PLUGIN_VERSION__ : "0.48.1";
+export const PLUGIN_VERSION = typeof __VERCEL_PLUGIN_VERSION__ === "string" ? __VERCEL_PLUGIN_VERSION__ : "0.49.0";
 const ACTIVE_SESSION_TTL_MS = 60 * 60 * 1000;
 
 const DAU_STAMP_PATH = join(homedir(), ".config", "vercel-plugin", "dau-stamp");
@@ -44,6 +44,10 @@ export interface ActiveSessionMarker {
   pluginVersion: string;
   updatedAt: number;
   expiresAt: number;
+  // Optional so the marker stays schema 1. The shipped CLI reader rejects any
+  // other schema outright, so a bump would blank out the plugin cohort fields
+  // it already reads until every user upgrades their CLI.
+  installId?: string;
 }
 
 async function sendTelemetry(
@@ -237,12 +241,14 @@ export function refreshActiveSessionMarker(now: Date = new Date()): void {
   }
 
   const updatedAt = now.getTime();
+  const installId = getOrCreateInstallationId();
   const marker: ActiveSessionMarker = {
     schema: 1,
     active: true,
     pluginVersion: PLUGIN_VERSION,
     updatedAt,
     expiresAt: updatedAt + ACTIVE_SESSION_TTL_MS,
+    ...(installId ? { installId } : {}),
   };
 
   try {

--- a/hooks/telemetry.mjs
+++ b/hooks/telemetry.mjs
@@ -5,7 +5,7 @@ import { join, dirname } from "path";
 import { homedir } from "os";
 var BRIDGE_ENDPOINT = "https://telemetry.vercel.com/api/vercel-plugin/v1/events";
 var FLUSH_TIMEOUT_MS = 3e3;
-var PLUGIN_VERSION = true ? "0.48.1" : "0.48.1";
+var PLUGIN_VERSION = true ? "0.49.0" : "0.49.0";
 var ACTIVE_SESSION_TTL_MS = 60 * 60 * 1e3;
 var DAU_STAMP_PATH = join(homedir(), ".config", "vercel-plugin", "dau-stamp");
 var FIRST_USE_STAMP_PATH = join(homedir(), ".config", "vercel-plugin", "first-use-stamp");
@@ -156,12 +156,14 @@ function refreshActiveSessionMarker(now = /* @__PURE__ */ new Date()) {
     return;
   }
   const updatedAt = now.getTime();
+  const installId = getOrCreateInstallationId();
   const marker = {
     schema: 1,
     active: true,
     pluginVersion: PLUGIN_VERSION,
     updatedAt,
-    expiresAt: updatedAt + ACTIVE_SESSION_TTL_MS
+    expiresAt: updatedAt + ACTIVE_SESSION_TTL_MS,
+    ...installId ? { installId } : {}
   };
   try {
     mkdirSync(dirname(ACTIVE_SESSION_MARKER_PATH), { recursive: true });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel-plugin",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "private": true,
   "license": "Apache-2.0",
   "bin": {

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -145,9 +145,10 @@ describe("telemetry controls", () => {
     expect(result.activeSessionMarker).toEqual({
       schema: 1,
       active: true,
-      pluginVersion: "0.48.1",
+      pluginVersion: "0.49.0",
       updatedAt: Date.parse("2026-05-15T12:00:00.000Z"),
       expiresAt: Date.parse("2026-05-15T13:00:00.000Z"),
+      installId: result.installationId,
     });
     expect(result.dauPayloads).toEqual([
       [
@@ -161,7 +162,7 @@ describe("telemetry controls", () => {
         }),
         expect.objectContaining({
           key: "plugin:version",
-          value: "0.48.1",
+          value: "0.49.0",
         }),
         expect.objectContaining({
           key: "plugin:install_id",
@@ -198,6 +199,17 @@ describe("telemetry controls", () => {
         (event) => event.key === "plugin:install_id",
       )?.value,
     ).toBe(result.installationId);
+  });
+
+  test("active-session marker carries the same installation ID on schema 1", async () => {
+    const result = await runTelemetryProbe({ agentHarness: "codex" });
+    const marker = result.activeSessionMarker as {
+      schema: number;
+      installId?: string;
+    };
+
+    expect(marker.schema).toBe(1);
+    expect(marker.installId).toBe(result.installationId);
   });
 
   test("concurrent invalid-file repairs leave a valid installation ID", async () => {


### PR DESCRIPTION
## Summary

Adds the installation UUID to `active-session.json` so Vercel CLI telemetry can attribute a command to the plugin installation that ran it.

#136 added `plugin:install_id` to the plugin's own phone-home but deliberately kept it out of the marker. The CLI only reads the marker, so today it can tell that a command ran inside a plugin session but not which installation that session belonged to. Consumer PR: vercel/vercel#17542. Tracked in PIPE-6602.

## Changes

- `hooks/src/telemetry.mts` — `installId?: string` on `ActiveSessionMarker`, populated from the existing `getOrCreateInstallationId()`
- `README.md` — the telemetry section stated the ID is never written to the marker, which this changes
- Version 0.48.1 → 0.49.0, hook bundle rebuilt
- Test coverage for the new field

## Stays on schema 1

The field is additive and optional, so older readers ignore it. A bump would actively break things: the shipped CLI reader does a hard `marker.schema !== 1 → return null`, so schema 2 would blank out `vercel_plugin_active_session` and `vercel_plugin_version` for everyone until they upgrade their CLI.

Optional rather than required because `getOrCreateInstallationId()` returns null when the file can't be written or read back.

## Tests

```bash
bun test          # 975 passing
bun run validate  # clean
```

## Rollout note

`anthropics/claude-plugins-official` pins this repo to commit `19606ac` (0.45.1), 10 commits behind main. #136 is inside that gap, so the official-marketplace population isn't emitting `plugin:install_id` yet and won't pick this up either until that pin moves.
