### PR TITLE
fix(hooks): extend session cleanup timeout

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -24,7 +24,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/session-end-cleanup.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/session-end-cleanup.mjs\"",
+            "timeout": 15
           }
         ]
       }

--- a/tests/session-end-cleanup.test.ts
+++ b/tests/session-end-cleanup.test.ts
@@ -77,6 +77,22 @@ describe("session-end-cleanup", () => {
 });
 
 describe("hooks.json wiring", () => {
+  test("gives session cleanup enough time during contended teardown", () => {
+    const config = JSON.parse(readFileSync(HOOKS_CONFIG_PATH, "utf-8")) as {
+      hooks?: {
+        SessionEnd?: Array<{
+          hooks?: Array<{ type?: string; command?: string; timeout?: number }>;
+        }>;
+      };
+    };
+
+    const cleanupHook = config.hooks?.SessionEnd
+      ?.flatMap((entry) => entry.hooks ?? [])
+      .find((hook) => hook.command?.includes("session-end-cleanup.mjs"));
+
+    expect(cleanupHook?.timeout).toBe(15);
+  });
+
   test("does not register the Agent pretooluse observer hook", () => {
     const config = JSON.parse(readFileSync(HOOKS_CONFIG_PATH, "utf-8")) as {
       hooks?: {


### PR DESCRIPTION
Closes #122

## Summary
- give the SessionEnd cleanup hook a 15-second teardown budget
- preserve fast normal exits while avoiding Claude Code's 1.5-second default cancellation
- add a regression assertion for the hook configuration

## Verification
- `npx --yes bun test tests/session-end-cleanup.test.ts` (4 passed)
- `npx --yes bun test tests/hooks-json-structural.test.ts` (6 passed)
- `git diff --check`

The repository-wide structural validator still reports five pre-existing command/catalog failures unrelated to this change.