### PR TITLE
Bump to 0.49.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "Build and deploy web apps and agents",
   "author": {
     "name": "Vercel",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "Build and deploy web apps and agents",
   "author": {
     "name": "Vercel",

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel-plugin",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "Comprehensive Vercel ecosystem plugin — relational knowledge graph, skills for every major product, specialized agents, and Vercel conventions. Turns any AI agent into a Vercel expert.",
   "keywords": [
     "vercel",

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel-plugin",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "Comprehensive Vercel ecosystem plugin — relational knowledge graph, skills for every major product, specialized agents, and Vercel conventions. Turns any AI agent into a Vercel expert.",
   "author": {
     "name": "Vercel",

--- a/hooks/src/telemetry.mts
+++ b/hooks/src/telemetry.mts
@@ -7,7 +7,7 @@ declare const __VERCEL_PLUGIN_VERSION__: string;
 
 const BRIDGE_ENDPOINT = "https://telemetry.vercel.com/api/vercel-plugin/v1/events";
 const FLUSH_TIMEOUT_MS = 3_000;
-export const PLUGIN_VERSION = typeof __VERCEL_PLUGIN_VERSION__ === "string" ? __VERCEL_PLUGIN_VERSION__ : "0.48.1";
+export const PLUGIN_VERSION = typeof __VERCEL_PLUGIN_VERSION__ === "string" ? __VERCEL_PLUGIN_VERSION__ : "0.49.0";
 const ACTIVE_SESSION_TTL_MS = 60 * 60 * 1000;
 
 const DAU_STAMP_PATH = join(homedir(), ".config", "vercel-plugin", "dau-stamp");

--- a/hooks/telemetry.mjs
+++ b/hooks/telemetry.mjs
@@ -5,7 +5,7 @@ import { join, dirname } from "path";
 import { homedir } from "os";
 var BRIDGE_ENDPOINT = "https://telemetry.vercel.com/api/vercel-plugin/v1/events";
 var FLUSH_TIMEOUT_MS = 3e3;
-var PLUGIN_VERSION = true ? "0.48.1" : "0.48.1";
+var PLUGIN_VERSION = true ? "0.49.0" : "0.49.0";
 var ACTIVE_SESSION_TTL_MS = 60 * 60 * 1e3;
 var DAU_STAMP_PATH = join(homedir(), ".config", "vercel-plugin", "dau-stamp");
 var FIRST_USE_STAMP_PATH = join(homedir(), ".config", "vercel-plugin", "first-use-stamp");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel-plugin",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "private": true,
   "license": "Apache-2.0",
   "bin": {

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -145,7 +145,7 @@ describe("telemetry controls", () => {
     expect(result.activeSessionMarker).toEqual({
       schema: 1,
       active: true,
-      pluginVersion: "0.48.1",
+      pluginVersion: "0.49.0",
       updatedAt: Date.parse("2026-05-15T12:00:00.000Z"),
       expiresAt: Date.parse("2026-05-15T13:00:00.000Z"),
     });
@@ -161,7 +161,7 @@ describe("telemetry controls", () => {
         }),
         expect.objectContaining({
           key: "plugin:version",
-          value: "0.48.1",
+          value: "0.49.0",
         }),
         expect.objectContaining({
           key: "plugin:install_id",


### PR DESCRIPTION
## Summary
- Minor bump to **0.49.0** after flags-sdk landed in #154 (plus backend skill link polish from #148).
- Syncs version across plugin manifests, `package.json`, and telemetry.

## Test plan
- [ ] CI green (typecheck / test / validate)
- [ ] Confirm `.plugin/plugin.json` reads `0.49.0`