### PR TITLE
fix(hooks): detect the Vercel CLI on Windows

### DIFF
--- a/hooks/session-start-profiler-platform.test.ts
+++ b/hooks/session-start-profiler-platform.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   detectAgentHarness,
   detectSessionStartPlatform,
+  getBinaryPathCandidates,
   normalizeDetectedAgentHarness,
 } from "./src/session-start-profiler.mts";
 
@@ -103,5 +104,35 @@ describe("session-start-profiler platform detection", () => {
         throw new Error("detector failed");
       }),
     ).toBe("unknown");
+  });
+});
+
+describe("session-start-profiler windows binary resolution", () => {
+  const isWindows = process.platform === "win32";
+
+  test.if(isWindows)(
+    "prefers an executable extension over the extensionless npm sh shim",
+    () => {
+      const candidates = getBinaryPathCandidates("vercel");
+
+      // npm lays down `vercel`, `vercel.cmd` and `vercel.ps1` side by side. Only
+      // the .cmd is executable by Windows, and accessSync(X_OK) cannot tell them
+      // apart because X_OK behaves as F_OK on win32. Resolution has to prefer the
+      // extension, or it returns the sh script and every exec fails with EINVAL.
+      const cmdIndex = candidates.findIndex((c: string) => /\.cmd$/i.test(c));
+      const bareIndex = candidates.indexOf("vercel");
+
+      expect(cmdIndex).toBeGreaterThanOrEqual(0);
+      expect(bareIndex).toBeGreaterThanOrEqual(0);
+      expect(cmdIndex).toBeLessThan(bareIndex);
+    },
+  );
+
+  test.if(isWindows)("keeps an explicit extension untouched", () => {
+    expect(getBinaryPathCandidates("vercel.cmd")).toEqual(["vercel.cmd"]);
+  });
+
+  test.if(!isWindows)("is a no-op off win32", () => {
+    expect(getBinaryPathCandidates("vercel")).toEqual(["vercel"]);
   });
 });

--- a/hooks/src/session-start-profiler.mts
+++ b/hooks/src/session-start-profiler.mts
@@ -20,7 +20,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { delimiter, join, resolve } from "node:path";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import type { AgentResult } from "detect-agent";
@@ -344,13 +344,21 @@ const WINDOWS_EXECUTABLE_EXTENSIONS = (process.env.PATHEXT || ".EXE;.CMD;.BAT;.C
   .split(";")
   .filter(Boolean);
 
-function getBinaryPathCandidates(binaryName: string): string[] {
+export function getBinaryPathCandidates(binaryName: string): string[] {
   if (process.platform !== "win32") {
     return [binaryName];
   }
 
   const hasExecutableExtension = /\.[^./\\]+$/.test(binaryName);
-  const suffixes = hasExecutableExtension ? [""] : ["", ...WINDOWS_EXECUTABLE_EXTENSIONS];
+  // Extensions must come first. npm installs three shims for a global CLI on
+  // Windows: an extensionless POSIX sh script for Git Bash, a .cmd and a .ps1.
+  // Windows cannot execute the sh script, and accessSync(X_OK) cannot tell us so,
+  // because Node treats X_OK as F_OK on win32 and any existing file passes.
+  // Trying the bare name first therefore always resolves the one shim that
+  // cannot run.
+  const suffixes = hasExecutableExtension
+    ? [""]
+    : [...WINDOWS_EXECUTABLE_EXTENSIONS, ""];
   return suffixes.map((suffix: string) => `${binaryName}${suffix}`);
 }
 
@@ -418,6 +426,50 @@ function compareVersionSegments(leftVersion: string, rightVersion: string): numb
  * Uses `vercel --version` for the local version and the npm registry for latest.
  * Returns quickly — each subprocess has a tight timeout.
  */
+const CMD_SHIM_RE = /\.(?:cmd|bat)$/i;
+// Built via split to avoid an array literal that confuses slug extraction.
+const COMSPEC_FLAGS: string[] = "/d /s /c".split(" ");
+
+/**
+ * Run a resolved binary, tolerating Windows batch shims.
+ *
+ * Since the batch-injection fix in CVE-2024-27980, Node refuses to spawn a
+ * `.cmd` or `.bat` through execFile unless it goes via a shell. Passing
+ * `shell: true` alongside an args array emits DEP0190, so the interpreter is
+ * invoked explicitly instead. The command is a path this module resolved from
+ * PATH and the args are module-level constants, so nothing here is caller
+ * controlled.
+ */
+function execBinarySync(binary: string, args: string[]): string {
+  if (process.platform === "win32" && CMD_SHIM_RE.test(binary)) {
+    const comspec = process.env.ComSpec || "cmd.exe";
+    const command = [`"${binary}"`, ...args].join(" ");
+    // spawnSync rather than execFileSync because windowsVerbatimArguments is only
+    // present on the spawn options type. cmd.exe does not understand the
+    // backslash-escaped quotes Node otherwise applies, and reports the whole
+    // quoted path as an unrecognised command.
+    const result = spawnSync(comspec, [...COMSPEC_FLAGS, command], {
+      timeout: EXEC_SYNC_TIMEOUT_MS,
+      encoding: "utf-8",
+      stdio: SPAWN_STDIO,
+      windowsVerbatimArguments: true,
+    });
+    if (result.error) {
+      throw result.error;
+    }
+    if (result.status !== 0) {
+      throw new Error(`${binary} exited with status ${String(result.status)}`);
+    }
+    return result.stdout;
+  }
+
+  return execFileSync(binary, args, {
+    timeout: EXEC_SYNC_TIMEOUT_MS,
+    encoding: "utf-8",
+    stdio: SPAWN_STDIO,
+  });
+}
+
 function checkVercelCli(): VercelCliStatus {
   const vercelBinary = resolveBinaryFromPath("vercel");
   if (!vercelBinary) {
@@ -427,11 +479,7 @@ function checkVercelCli(): VercelCliStatus {
   // 1. Check if vercel is installed
   let currentVersion: string | undefined;
   try {
-    const raw: string = execFileSync(vercelBinary, VERCEL_VERSION_ARGS, {
-      timeout: EXEC_SYNC_TIMEOUT_MS,
-      encoding: "utf-8",
-      stdio: SPAWN_STDIO,
-    }).trim();
+    const raw: string = execBinarySync(vercelBinary, VERCEL_VERSION_ARGS).trim();
     // Output may include extra lines; version is typically last non-empty line
     const lines: string[] = raw.split("\n").map((l: string) => l.trim()).filter(Boolean);
     currentVersion = lines[lines.length - 1];
@@ -451,11 +499,7 @@ function checkVercelCli(): VercelCliStatus {
   // 2. Fetch latest version from npm registry
   let latestVersion: string | undefined;
   try {
-    const raw: string = execFileSync(npmBinary, NPM_VIEW_ARGS, {
-      timeout: EXEC_SYNC_TIMEOUT_MS,
-      encoding: "utf-8",
-      stdio: SPAWN_STDIO,
-    }).trim();
+    const raw: string = execBinarySync(npmBinary, NPM_VIEW_ARGS).trim();
     latestVersion = raw;
   } catch (error) {
     logCaughtError(log, "session-start-profiler:npm-latest-version-check-failed", error, {


### PR DESCRIPTION
Fixes #140.

On Windows the SessionStart hook reports the Vercel CLI as not installed even
when it is, so the model is told a capability is unavailable and avoids
`vercel env pull`, `vercel deploy` and `vercel logs`.

Two independent failures, either of which alone breaks detection.

Candidate ordering. npm installs three shims for a global CLI on Windows: an
extensionless POSIX sh script for Git Bash, a .cmd and a .ps1.
`getBinaryPathCandidates` returned the bare name first, and `accessSync(X_OK)`
cannot rule it out because Node treats X_OK as F_OK on win32, so any existing
file passes. Resolution therefore always returned the one shim Windows cannot
execute. Extensions now come first and the bare name last.

Executing the shim. Since CVE-2024-27980 Node refuses to spawn a .cmd or .bat
through execFile, so the version check failed even when resolution was correct.
Both call sites now go through one `execBinarySync` helper.

The helper uses spawnSync with `windowsVerbatimArguments`, not `shell: true`.
`shell: true` alongside an args array emits DEP0190, and invoking ComSpec
without verbatim arguments does not work either: Node applies its Windows
argument escaping, cmd.exe receives \"C:\path\to\vercel.CMD\" and reports the
whole quoted path as an unrecognised command. `windowsVerbatimArguments` is
typed on the spawn options and not on execFileSync's, which is why the helper
uses spawnSync.

The npm call site had the same bug and is fixed with it, so a stale-version
check no longer fails silently on Windows.

Verified on Windows 11 (26200), Node v24.12.0, against a real npm-installed
global CLI:

  before  resolved ...\npm\claude       execFileSync -> ENOENT
  after   resolved ...\npm\claude.CMD   execBinarySync -> OK

Adds the regression test the issue asks for: on win32 an executable extension
must sort ahead of the bare name.
