### PR TITLE
Sync flags skill updates; bump to 0.49.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel",
-  "version": "0.49.0",
+  "version": "0.49.1",
   "description": "Build and deploy web apps and agents",
   "author": {
     "name": "Vercel",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel",
-  "version": "0.49.0",
+  "version": "0.49.1",
   "description": "Build and deploy web apps and agents",
   "author": {
     "name": "Vercel",

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel-plugin",
-  "version": "0.49.0",
+  "version": "0.49.1",
   "description": "Comprehensive Vercel ecosystem plugin — relational knowledge graph, skills for every major product, specialized agents, and Vercel conventions. Turns any AI agent into a Vercel expert.",
   "keywords": [
     "vercel",

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel-plugin",
-  "version": "0.49.0",
+  "version": "0.49.1",
   "description": "Comprehensive Vercel ecosystem plugin — relational knowledge graph, skills for every major product, specialized agents, and Vercel conventions. Turns any AI agent into a Vercel expert.",
   "author": {
     "name": "Vercel",

--- a/generated/skill-manifest.json
+++ b/generated/skill-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-09-08T06:36:27.856Z",
+  "generatedAt": "2026-09-09T07:34:01.295Z",
   "version": 2,
   "skills": {
     "access-protected-vercel-deployment": {
@@ -2020,7 +2020,15 @@
           "kill switch",
           "flag variant",
           "flag adapter",
-          "precompute flags"
+          "precompute flags",
+          "traffic split",
+          "targeting rules",
+          "flag rules",
+          "flag segments",
+          "flag targeting",
+          "flag evaluations",
+          "flag overrides",
+          "existing flag"
         ],
         "allOf": [
           [
@@ -2060,7 +2068,8 @@
           "command line flag",
           "cli flag",
           "compiler flag",
-          "flag emoji"
+          "flag emoji",
+          "rolling release"
         ],
         "minScore": 6
       },

--- a/hooks/src/telemetry.mts
+++ b/hooks/src/telemetry.mts
@@ -7,7 +7,7 @@ declare const __VERCEL_PLUGIN_VERSION__: string;
 
 const BRIDGE_ENDPOINT = "https://telemetry.vercel.com/api/vercel-plugin/v1/events";
 const FLUSH_TIMEOUT_MS = 3_000;
-export const PLUGIN_VERSION = typeof __VERCEL_PLUGIN_VERSION__ === "string" ? __VERCEL_PLUGIN_VERSION__ : "0.49.0";
+export const PLUGIN_VERSION = typeof __VERCEL_PLUGIN_VERSION__ === "string" ? __VERCEL_PLUGIN_VERSION__ : "0.49.1";
 const ACTIVE_SESSION_TTL_MS = 60 * 60 * 1000;
 
 const DAU_TOPIC_ID = "dau";

--- a/hooks/telemetry.mjs
+++ b/hooks/telemetry.mjs
@@ -5,7 +5,7 @@ import { join, dirname } from "path";
 import { homedir } from "os";
 var BRIDGE_ENDPOINT = "https://telemetry.vercel.com/api/vercel-plugin/v1/events";
 var FLUSH_TIMEOUT_MS = 3e3;
-var PLUGIN_VERSION = true ? "0.49.0" : "0.49.0";
+var PLUGIN_VERSION = true ? "0.49.1" : "0.49.1";
 var ACTIVE_SESSION_TTL_MS = 60 * 60 * 1e3;
 var DAU_TOPIC_ID = "dau";
 var SKILL_TOPIC_ID = "generic";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel-plugin",
-  "version": "0.49.0",
+  "version": "0.49.1",
   "private": true,
   "license": "Apache-2.0",
   "bin": {

--- a/skills/flags-sdk/SKILL.md
+++ b/skills/flags-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flags-sdk
-description: Flags SDK and Vercel Flags expert guidance. Use when declaring feature flags with flag(), wiring provider adapters (Vercel, Statsig, LaunchDarkly, PostHog, and others), managing flags with the vercel flags CLI, implementing the precompute pattern for static A/B tests, or integrating the Flags Explorer.
+description: "Set up and use feature flags and A/B tests with the Flags SDK (`flags` npm package) and Vercel Flags. Use when installing or configuring the SDK, adding a new or existing flag, wiring `vercelAdapter` (OIDC or SDK keys), declaring flags with `flag()`, using the `vercel flags` CLI (create, inspect, list, enable, disable, set, update, split, rollout, rules, segments, use-targeting, evaluations, versions, open, archive, unarchive, rm, sdk-keys, override, prepare), setting up providers/adapters (Vercel, Statsig, LaunchDarkly, PostHog, GrowthBook, Global Config, OpenFeature, Split, Flagsmith, Reflag, Optimizely, or custom), precompute, `identify`/`dedupe`, Flags Explorer/Toolbar, Next.js or SvelteKit, or encrypting flag values. Triggers: feature flags, feature gates, A/B testing, experimentation, gradual rollout, traffic split, targeting rules, flag overrides, precompute, Flags Explorer, Vercel Flags, vercel flags CLI, `flags/next`, `flags/sveltekit`, `flags/react`, `@flags-sdk/*`."
 summary: "Flags SDK guidance — declare flags with flag(), connect provider adapters, manage Vercel Flags via the vercel flags CLI, precompute static variants, and set up the Flags Explorer."
 metadata:
   priority: 6
@@ -54,6 +54,14 @@ metadata:
       - "flag variant"
       - "flag adapter"
       - "precompute flags"
+      - "traffic split"
+      - "targeting rules"
+      - "flag rules"
+      - "flag segments"
+      - "flag targeting"
+      - "flag evaluations"
+      - "flag overrides"
+      - "existing flag"
     allOf:
       - [flag, rollout]
       - [flag, variant]
@@ -73,6 +81,7 @@ metadata:
       - "cli flag"
       - "compiler flag"
       - "flag emoji"
+      - "rolling release"
     minScore: 6
 retrieval:
   aliases:
@@ -105,12 +114,14 @@ chainTo:
     message: 'Global Config flag adapter detected — loading Vercel storage guidance for Global Config setup and limits.'
 ---
 
-# Flags SDK
+# Set up and use the Flags SDK
 
 The Flags SDK (`flags` npm package) is a feature flags toolkit for Next.js and SvelteKit. It turns each feature flag into a callable function, works with any flag provider via adapters, and keeps pages static using the precompute pattern. Vercel Flags is the first-party provider, letting you manage flags from the Vercel dashboard or the `vercel flags` CLI.
 
 - Docs: https://flags-sdk.dev
 - Repo: https://github.com/vercel/flags
+
+When the user asks to install, configure, or set up feature flags, follow [Set up the SDK](#set-up-the-sdk) (including `vercel env pull` when `.env.local` is missing). When they ask to create or add a flag, follow [Create a flag](#create-a-flag). Do not leave CLI steps as "next steps" for the user — execute them yourself.
 
 ## Core concepts
 
@@ -149,9 +160,9 @@ export const exampleFlag = flag({
 
 > **Version note**: The SDK is published as `flags` (renamed from `@vercel/flags`; that old name still appears in changelog history). `flags` 4.2.0+ accepts the adapter factory by reference (`adapter: vercelAdapter`) and resolves it once per declaration. Older versions require calling it (`adapter: vercelAdapter()`). The called form still works on new versions, so prefer the shorthand unless you're targeting `flags` < 4.2.0.
 
-## Agent workflow: Creating a new flag
+## Set up the SDK
 
-When a user asks you to create or add a feature flag, follow these steps in order. Do not leave CLI steps as "next steps" for the user — execute them yourself.
+One-time project setup. Run this when the Flags SDK is not installed yet, or when Toolbar / Flags Explorer / `.env.local` are missing. Skip any step that is already done.
 
 ### Before you start
 
@@ -160,10 +171,10 @@ Check the project state to adapt commands and decide which steps you can skip:
 - Which lockfile is present (`pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`, `bun.lockb`)? → Adapt all package manager commands accordingly (`pnpm add`, `npm install`, `yarn add`, `bun add`).
 - Is `flags` in `package.json`? → Skip install (step 1)
 - Does `.vercel/` directory exist? → Project is linked, skip `vercel link` in step 2
-- Does `.env.local` contain `FLAGS=`? → Env vars already pulled, skip step 3
-- Does `flags.ts` (or `lib/flags.ts`, `src/flags.ts`) exist? → Add to it rather than creating from scratch (step 4)
-- Is `@vercel/toolbar` in `package.json`? → Skip toolbar setup (step 6)
-- Does `app/.well-known/vercel/flags/route.ts` exist? → Flags Explorer already set up, skip step 7
+- Does `.env.local` contain `VERCEL_OIDC_TOKEN=` (or a `FLAGS=` SDK key)? → Env vars already pulled, skip step 3
+- Is `@vercel/toolbar` in `package.json`? → Skip toolbar setup (step 4)
+- Does `flags.ts` (or `lib/flags.ts`, `src/flags.ts`) exist? → Skip creating it (step 5)
+- Does `app/.well-known/vercel/flags/route.ts` exist? → Flags Explorer already set up, skip step 6
 
 ### Steps
 
@@ -172,13 +183,52 @@ Check the project state to adapt commands and decide which steps you can skip:
    pnpm i flags @flags-sdk/vercel
    ```
 
-2. **Register the flag with Vercel**: Run `vercel flags add <flag-key> --kind boolean --description "<description>"`.
-
+2. **Link the project to Vercel** (required for `vercel flags` and env vars):
    > **Prerequisite**: The `vercel flags` commands require the Vercel CLI to be installed and authenticated. If the Vercel CLI is not installed, run `pnpm i -g vercel`. For authentication or linking issues, follow the `vercel-cli` skill if it's already available. If it isn't, suggest the user install it with `npx skills add vercel/vercel@vercel-cli` (don't auto-install it) and rely on `vercel <command> --help` in the meantime.
 
-   Before running `vercel flags add`, verify the project is linked to Vercel. Check for a `.vercel` directory in the project root. If it doesn't exist, run `vercel link` first.
+   Check for a `.vercel` directory in the project root. If it doesn't exist, run `vercel link`.
 
-3. **Pull environment variables**: Run `vercel env pull` to write `FLAGS` and `FLAGS_SECRET` to `.env.local`. Without these environment variables, `vercelAdapter` will not be able to evaluate flags. This step is **mandatory** after creating a flag.
+3. **Pull environment variables**: If `.env.local` lacks `VERCEL_OIDC_TOKEN=`, follow [Pull environment variables](#pull-environment-variables).
+
+4. **Set up the Vercel Toolbar** (if not already present):
+   - Run `pnpm i @vercel/toolbar`
+   - Wrap `next.config.ts` with the toolbar plugin
+   - Render `<VercelToolbar />` in the root layout
+   See [references/nextjs.md — Toolbar Setup](references/nextjs.md#toolbar-setup) for the full code.
+
+5. **Ensure `flags.ts` exists**: If missing, create `flags.ts` (or `lib/flags.ts` / `src/flags.ts` to match the project) with `export {}` so TypeScript treats it as a module. Flags Explorer imports this file — create it before the discovery route.
+
+6. **Set up Flags Explorer** (if not already present): Create `app/.well-known/vercel/flags/route.ts` — see [Flags Explorer setup](#flags-explorer-setup). Do this only after `flags.ts` exists. Point the import at the real flags file path (the snippet assumes root `flags.ts`).
+
+## Pull environment variables
+
+`vercel env pull` writes the Development credentials to `.env.local`: the Vercel OIDC token that `vercelAdapter` uses locally (deployments receive it automatically, [Getting started](https://vercel.com/docs/flags/vercel-flags/quickstart#pull-local-openid-connect-credentials)) and the Development `FLAGS_SECRET` for Flags Explorer and overrides. Run it when:
+
+- `.env.local` lacks `VERCEL_OIDC_TOKEN=` (or a `FLAGS=` SDK key)
+- you created the project's first flag; activating Vercel Flags creates a `FLAGS_SECRET` per environment
+- local evaluation fails with an authentication error; the SDK refreshes an expired token through the linked project, re-pulling is the fallback
+
+SDK keys (`FLAGS`) are only for apps outside Vercel, custom environments, or flags of another project ([SDK Keys](https://vercel.com/docs/flags/vercel-flags/dashboard/sdk-keys)). If `FLAGS_SECRET` is still missing after the pull, generate it per [FLAGS_SECRET](#flags_secret).
+
+## Create a flag
+
+When a user asks you to create or add a feature flag that does not exist on Vercel yet, follow these steps in order. If the flag was already created in the dashboard (the prompt says so, or `vercel flags create` reports the key exists), follow [Add a flag that already exists on Vercel](#add-a-flag-that-already-exists-on-vercel) instead.
+
+### Before you start
+
+- Complete [Set up the SDK](#set-up-the-sdk) first if packages, Vercel link, `.env.local`, Toolbar, `flags.ts`, or Flags Explorer are missing. Skip steps that are already done.
+- Does `.env.local` contain `VERCEL_OIDC_TOKEN=`? → Env vars already pulled; see [Pull environment variables](#pull-environment-variables) if local evaluation fails with an authentication error.
+- Does `flags.ts` (or `lib/flags.ts`, `src/flags.ts`) exist? → Add to it rather than creating from scratch.
+
+### Steps
+
+1. **Ensure the SDK is set up**: Follow [Set up the SDK](#set-up-the-sdk) if needed, then continue.
+
+2. **Register the flag with Vercel**: Run `vercel flags create <flag-key> --kind boolean --description "<description>"`.
+
+   Before running `vercel flags create`, verify the project is linked (`.vercel` directory). If missing, run `vercel link` first.
+
+3. **Pull environment variables**: If this is the project's first flag, follow [Pull environment variables](#pull-environment-variables) again; activation created the `FLAGS_SECRET`.
 
 4. **Declare the flag in code**: Add it to `flags.ts` (or create the file if it doesn't exist) using `vercelAdapter`:
    ```ts
@@ -201,25 +251,43 @@ Check the project state to adapt commands and decide which steps you can skip:
    }
    ```
 
-6. **Set up the Vercel Toolbar** (if not already present):
-   - Run `pnpm i @vercel/toolbar`
-   - Wrap `next.config.ts` with the toolbar plugin
-   - Render `<VercelToolbar />` in the root layout
-   See [references/nextjs.md — Toolbar Setup](references/nextjs.md#toolbar-setup) for the full code.
+## Add a flag that already exists on Vercel
 
-7. **Set up Flags Explorer** (if not already present): Create `app/.well-known/vercel/flags/route.ts` — see the [Flags Explorer setup](#flags-explorer-setup) section below.
+Use this flow when the flag was created in the dashboard or by someone else, for example when the prompt says the flag "has already been created" or asks you to run `vercel flags inspect`. Do not run `vercel flags create` for an existing key.
+
+1. **Ensure the SDK is set up**: Follow [Set up the SDK](#set-up-the-sdk) if needed.
+2. **Read the definition**: Run `vercel flags inspect <flag-key>`. Note the kind, the variants (value and label), the description, and what each environment serves.
+3. **Pull environment variables**: If `.env.local` lacks `VERCEL_OIDC_TOKEN=`, follow [Pull environment variables](#pull-environment-variables).
+4. **Declare the flag**: Add it to `flags.ts` with `vercelAdapter`. Map the `inspect` output:
+   - `key`: the flag key exactly as printed
+   - kind → type parameter: `boolean` → `flag<boolean>`, `string` → `flag<string>`, `number` → `flag<number>`, `json` → `flag<YourType>`
+   - `description`: copy from `inspect`
+   - `defaultValue`: the value to serve when the flag is archived or evaluation fails (usually what production serves today)
+   - `options`: optional; mirror the variants when you use precompute or want them listed in Flags Explorer
+   - `identify`: add or reuse one when the flag has targeting, using the entity attributes configured in the dashboard (see [Flag with evaluation context](#flag-with-evaluation-context))
+   ```ts
+   export const welcomeMessage = flag<string>({
+     key: 'welcome-message',
+     description: 'Copy shown on the landing page',
+     defaultValue: 'control',
+     adapter: vercelAdapter,
+   });
+   ```
+5. **Use the flag** as in [Create a flag](#create-a-flag) step 5.
 
 ## Vercel Flags
 
-Vercel Flags is Vercel's feature flags platform. You create and manage flags from the Vercel dashboard or the `vercel flags` CLI, then connect them to your code with the `@flags-sdk/vercel` adapter. When you create a flag in Vercel, the `FLAGS` and `FLAGS_SECRET` environment variables are configured automatically.
+Vercel Flags is Vercel's feature flags platform. You create and manage flags from the Vercel dashboard or the `vercel flags` CLI, then connect them to your code with the `@flags-sdk/vercel` adapter. `vercelAdapter()` authenticates with the project's Vercel OIDC token and evaluates the configuration of the current environment; SDK keys (`FLAGS`) are for manual authentication only ([SDK Keys](https://vercel.com/docs/flags/vercel-flags/dashboard/sdk-keys)). Activating Vercel Flags creates a `FLAGS_SECRET` per environment for Flags Explorer.
 
-To create a flag end-to-end, follow the [Agent workflow](#agent-workflow-creating-a-new-flag) above.
+To install the SDK, follow [Set up the SDK](#set-up-the-sdk). To create a flag end-to-end, follow [Create a flag](#create-a-flag). For a flag that already exists on Vercel, follow [Add a flag that already exists on Vercel](#add-a-flag-that-already-exists-on-vercel).
 
-For the full Vercel provider reference — user targeting, `vercel flags` CLI subcommands, custom adapter configuration, and Flags Explorer setup — see [references/providers.md](references/providers.md#vercel).
+For the full Vercel provider reference — user targeting, how the CLI maps to the SDK (keys, kinds, targeting attributes, SDK keys, overrides, `prepare`), lifecycle and safety, custom adapter configuration, and Flags Explorer setup — see [references/providers.md](references/providers.md#vercel).
+
+For the current `vercel flags` subcommands and options (targeting, splits, rollouts, rules, segments, evaluations, versions, and more), run `vercel flags --help` or `vercel flags <cmd> --help`. For CLI-wide contracts (linking, non-interactive mode, output parsing), use the `vercel-cli` skill.
 
 ## Declaring flags
 
-When using Vercel Flags, declare flags with `vercelAdapter` as shown in the [Agent workflow](#agent-workflow-creating-a-new-flag). For other providers, see [references/providers.md](references/providers.md). Below are the general `flag()` patterns.
+When using Vercel Flags, declare flags with `vercelAdapter` as shown in [Create a flag](#create-a-flag). For other providers, see [references/providers.md](references/providers.md). Below are the general `flag()` patterns.
 
 ### Basic flag
 
@@ -266,6 +334,8 @@ export const dashboardFlag = flag<boolean, Entities>({
   },
 });
 ```
+
+With `vercelAdapter`, the entity and attribute names in the returned object (`user.id` here) are what dashboard rules and `vercel flags split|rollout|rules --by` target. They must match the entities configured in the dashboard. See [references/providers.md — User targeting](references/providers.md#user-targeting).
 
 ### Flag with another adapter
 
@@ -353,7 +423,7 @@ Adapters can opt into batching by implementing the optional `bulkDecide` hook. T
 // app/.well-known/vercel/flags/route.ts
 import { createFlagsDiscoveryEndpoint } from 'flags/next';
 import { getProviderData } from '@flags-sdk/vercel';
-import * as flags from '../../../../flags';
+import * as flags from '../../../../flags'; // adjust if flags live under lib/ or src/
 
 export const GET = createFlagsDiscoveryEndpoint(async () => {
   return getProviderData(flags);
@@ -454,5 +524,5 @@ Detailed framework and provider guides are in separate files to keep context lea
 
 - **[references/nextjs.md](references/nextjs.md)**: Next.js quickstart, toolbar, App Router, Pages Router, middleware/proxy, precompute, dedupe, dashboard pages, marketing pages, suspense fallbacks
 - **[references/sveltekit.md](references/sveltekit.md)**: SvelteKit quickstart, toolbar, hooks setup, precompute with reroute + middleware, dashboard pages, marketing pages
-- **[references/providers.md](references/providers.md)**: All provider adapters — Vercel, Global Config, Statsig, LaunchDarkly, PostHog, GrowthBook, Hypertune, Flagsmith, Reflag, Split, Optimizely, OpenFeature, and custom adapters
+- **[references/providers.md](references/providers.md)**: All provider adapters — Vercel, Global Config, Statsig, LaunchDarkly, PostHog, GrowthBook, Flagsmith, Reflag, Split, Optimizely, OpenFeature, and custom adapters
 - **[references/api.md](references/api.md)**: Full API reference for `flags`, `flags/react`, `flags/next`, and `flags/sveltekit`

--- a/skills/flags-sdk/overlay.yaml
+++ b/skills/flags-sdk/overlay.yaml
@@ -1,5 +1,5 @@
 name: flags-sdk
-description: Flags SDK and Vercel Flags expert guidance. Use when declaring feature flags with flag(), wiring provider adapters (Vercel, Statsig, LaunchDarkly, PostHog, and others), managing flags with the vercel flags CLI, implementing the precompute pattern for static A/B tests, or integrating the Flags Explorer.
+description: "Set up and use feature flags and A/B tests with the Flags SDK (`flags` npm package) and Vercel Flags. Use when installing or configuring the SDK, adding a new or existing flag, wiring `vercelAdapter` (OIDC or SDK keys), declaring flags with `flag()`, using the `vercel flags` CLI (create, inspect, list, enable, disable, set, update, split, rollout, rules, segments, use-targeting, evaluations, versions, open, archive, unarchive, rm, sdk-keys, override, prepare), setting up providers/adapters (Vercel, Statsig, LaunchDarkly, PostHog, GrowthBook, Global Config, OpenFeature, Split, Flagsmith, Reflag, Optimizely, or custom), precompute, `identify`/`dedupe`, Flags Explorer/Toolbar, Next.js or SvelteKit, or encrypting flag values. Triggers: feature flags, feature gates, A/B testing, experimentation, gradual rollout, traffic split, targeting rules, flag overrides, precompute, Flags Explorer, Vercel Flags, vercel flags CLI, `flags/next`, `flags/sveltekit`, `flags/react`, `@flags-sdk/*`."
 summary: "Flags SDK guidance — declare flags with flag(), connect provider adapters, manage Vercel Flags via the vercel flags CLI, precompute static variants, and set up the Flags Explorer."
 metadata:
   priority: 6
@@ -53,6 +53,14 @@ metadata:
       - "flag variant"
       - "flag adapter"
       - "precompute flags"
+      - "traffic split"
+      - "targeting rules"
+      - "flag rules"
+      - "flag segments"
+      - "flag targeting"
+      - "flag evaluations"
+      - "flag overrides"
+      - "existing flag"
     allOf:
       - [flag, rollout]
       - [flag, variant]
@@ -72,6 +80,7 @@ metadata:
       - "cli flag"
       - "compiler flag"
       - "flag emoji"
+      - "rolling release"
     minScore: 6
 retrieval:
   aliases:

--- a/skills/flags-sdk/references/providers.md
+++ b/skills/flags-sdk/references/providers.md
@@ -8,7 +8,6 @@
 - [LaunchDarkly](#launchdarkly)
 - [PostHog](#posthog)
 - [GrowthBook](#growthbook)
-- [Hypertune](#hypertune)
 - [Flagsmith](#flagsmith)
 - [Reflag](#reflag)
 - [OpenFeature](#openfeature)
@@ -32,8 +31,8 @@ pnpm i flags @flags-sdk/vercel
 
 Before running any `vercel flags` command, verify the project is linked to Vercel. Check for a `.vercel` directory in the project root. If it doesn't exist, run `vercel link` first.
 
-1. Create a flag in the Vercel dashboard or via CLI: `vercel flags add <flag-key> --kind boolean --description "<description>"`
-2. Pull env vars: you **must** run `vercel env pull` to write `FLAGS` and `FLAGS_SECRET` to `.env.local`. Without these environment variables, `vercelAdapter` will not be able to evaluate flags.
+1. Create a flag in the Vercel dashboard or via CLI: `vercel flags create <flag-key> --kind boolean --description "<description>"`
+2. Pull env vars: run `vercel env pull` to write the Vercel OIDC token and the Development `FLAGS_SECRET` to `.env.local` ([Pull environment variables](../SKILL.md#pull-environment-variables)). See [Authentication](#how-the-cli-connects-to-the-sdk) for SDK keys.
 3. Declare the flag:
 
 ```ts
@@ -69,6 +68,8 @@ export const exampleFlag = flag<boolean, Entities>({
 });
 ```
 
+Define the entities and attributes under Flags → Entities in the dashboard before you use them in rules or segments, and return the same names from `identify` ([Entities](https://vercel.com/docs/flags/vercel-flags/dashboard/entities)). The example above allows `--by user.id` / `--by team.id` in `vercel flags split`, `rollout`, and `rules add`, and the matching conditions in dashboard rules. Entities are evaluated fresh on every call; a rule whose attribute is missing from the context is skipped. See [How the CLI connects to the SDK](#how-the-cli-connects-to-the-sdk).
+
 ### Flags Explorer
 
 ```ts
@@ -102,7 +103,7 @@ If the app also uses `@vercel/flags-core` directly, create the client once and p
 import { createClient } from '@vercel/flags-core';
 import { createVercelAdapter } from '@flags-sdk/vercel';
 
-const vercelFlagsClient = createClient(process.env.FLAGS);
+const vercelFlagsClient = createClient(); // Vercel OIDC token, on deployments and after `vercel env pull`
 const vercelAdapter = createVercelAdapter(vercelFlagsClient);
 
 export const exampleFlag = flag({
@@ -111,84 +112,37 @@ export const exampleFlag = flag({
 });
 ```
 
+Outside Vercel, pass the SDK key: `createClient(process.env.FLAGS)`. Unlike `vercelAdapter()`, `createClient()` does not read `FLAGS` on its own.
+
 ### `vercel flags` CLI
 
-Manage Vercel Flags from the terminal. Requires the [Vercel CLI](https://vercel.com/docs/cli) and a linked project.
+Manage Vercel Flags from the terminal. Install, link, and `vercel env pull` requirements are in [Setup](#setup) above.
 
-> **Prerequisite**: The Vercel CLI must be installed (`pnpm i -g vercel`) and the project must be linked (`vercel link` — check for a `.vercel` directory). For authentication issues, read and follow the `vercel-cli` skill.
+For the current subcommand list and options, run `vercel flags --help` or `vercel flags <cmd> --help`. For CLI-wide contracts (linking, `--non-interactive`, `--yes`, parsing stdout) follow the `vercel-cli` skill. This section covers only what `--help` cannot tell you.
 
-#### Subcommands
+#### How the CLI connects to the SDK
 
-| Subcommand   | Description                                           |
-| ------------ | ----------------------------------------------------- |
-| `list`       | List all flags in the project                         |
-| `add`        | Create a new flag                                     |
-| `inspect`    | Show details, status, and targeting rules of a flag   |
-| `enable`     | Enable a boolean flag for a specific environment      |
-| `disable`    | Disable a boolean flag for a specific environment     |
-| `archive`    | Archive a flag (required before deleting)              |
-| `rm`         | Delete an archived flag                               |
-| `sdk-keys`   | Manage SDK keys (subcommands: `ls`, `add`, `rm`)      |
+- **Key**: the flag slug you pass to the CLI is the `key` in `flag()`. The flag returns one of the variants you created on Vercel ([Run an A/B test](https://vercel.com/docs/flags/vercel-flags/cli/run-ab-test)).
+- **Kind → type**: `inspect <key>` prints the kind and variants. `boolean` → `flag<boolean>()`, `string` → `flag<string>()`, `number` → `flag<number>()`, `json` → `flag<YourType>()`. The kind is fixed at creation and cannot be changed ([Flag types](https://vercel.com/docs/flags/vercel-flags/dashboard/feature-flag#flag-types)).
+- **Variants → `options`**: `options` on the declaration are optional. They give Flags Explorer a dropdown, pre-fill the dashboard when a draft is promoted, and let precompute serialize values and `generatePermutations` enumerate them ([Declaring options](https://vercel.com/docs/flags/vercel-flags/sdks/flags-sdk#declaring-options)). When you declare them, keep them equal to the variants `inspect` shows.
+- **`defaultValue`**: a flag that is archived, or declared in code but not created on Vercel (a draft), evaluates to `defaultValue`. Without `defaultValue`, evaluation throws ([Archive](https://vercel.com/docs/flags/vercel-flags/dashboard/archive#what-happens-when-you-archive), [Drafts](https://vercel.com/docs/flags/vercel-flags/dashboard/drafts#draft-behavior)).
+- **Targeting attributes**: `split`, `rollout`, and `rules add` take `--by <entity>.<attribute>` (and `--condition <entity>.<attribute>:<op>:<value>`). Define the entity and attribute under Flags → Entities first, and return the same names from `identify()`; the docs use a `User` entity with an `id` attribute and `--by user.id` ([Roll out a feature](https://vercel.com/docs/flags/vercel-flags/cli/roll-out-feature), [Entities](https://vercel.com/docs/flags/vercel-flags/dashboard/entities)). When the attribute is missing from the context, a split or rollout serves its fallback variant (`--default-variant` in the CLI) and a rule that references it is skipped. Verify with `evaluations`.
+- **Authentication**: on Vercel, `vercelAdapter()` authenticates with the project's OIDC token and uses the configuration of the current environment; `vercel env pull` brings that credential to `.env.local` for local development. SDK keys (`FLAGS`) are for manual authentication: apps outside Vercel, custom environments, or flags owned by another project. Each SDK key is scoped to one environment and its full value is shown once, at creation ([Getting started](https://vercel.com/docs/flags/vercel-flags/quickstart#pull-local-openid-connect-credentials), [SDK Keys](https://vercel.com/docs/flags/vercel-flags/dashboard/sdk-keys)).
+- **Overrides**: Flags Explorer stores overrides in a cookie signed with `FLAGS_SECRET`; flags declared with the SDK honour it automatically ([Handling overrides](https://vercel.com/docs/flags/flags-explorer/getting-started#handling-overrides)). `vercel flags override <key>=<value>` produces the same token for the `vercel-flag-overrides` cookie and reads `FLAGS_SECRET` from the environment or `.env.local`, so use the secret of the environment you test against (see [FLAGS_SECRET](../SKILL.md#flags_secret)).
+- **Embedded definitions**: Vercel builds fetch the flag definitions once and bundle them into the deployment when the project uses `@flags-sdk/vercel` or `@vercel/flags-core` and the build can authenticate. This keeps every function on one snapshot and serves as the runtime fallback when the service is unreachable; opt out with `VERCEL_FLAGS_DISABLE_DEFINITION_EMBEDDING=1` ([Embedded definitions](https://vercel.com/docs/flags/vercel-flags/sdks/core#embedded-definitions)). `vercel flags prepare` is the same step for builds that run outside Vercel.
 
-#### Create and toggle a flag
+#### Lifecycle and safety
 
-```bash
-# Create a boolean flag with a description
-vercel flags add my-feature --kind boolean --description "New onboarding flow"
+The docs describe these flows end to end: [Roll out a feature](https://vercel.com/docs/flags/vercel-flags/cli/roll-out-feature), [Run an A/B test](https://vercel.com/docs/flags/vercel-flags/cli/run-ab-test), [Clean up after rollout](https://vercel.com/docs/flags/vercel-flags/cli/clean-up-after-rollout). Follow them; the notes below are the parts an agent gets wrong.
 
-# Enable in development first
-vercel flags enable my-feature --environment development
+- **Promote**: deploy the code to preview, `enable` or `set` the flag in preview, verify on the preview URL, deploy to production, then change production (`enable`, `set`, `split`, or `rollout`). Each environment keeps its own configuration; preview stays on its current value until you change it.
+- **Serve vs define**: `enable` / `disable` work on boolean flags only. `set` changes the served variant for any kind. `update` adds, removes, or renames variants and does not change what is served. A variant can only be removed when no environment configuration or rule references it, including rules that are stored but not active ([Deleting a variant](https://vercel.com/docs/flags/vercel-flags/dashboard/feature-flag#deleting-a-variant)).
+- **Static value vs targeting**: `set` / `enable` / `disable` put the environment in static value mode; its split, rollout, and rules are preserved in the background. `use-targeting` switches back to targets and rules mode ([Switching between static and rules modes](https://vercel.com/docs/flags/vercel-flags/dashboard/feature-flag#switching-between-static-and-rules-modes)). Run `inspect` first so you know what the environment serves today.
+- **Confirm a change**: `inspect` for the served state, `versions` for the change history (the dashboard can restore any earlier configuration), `evaluations` to confirm traffic reaches the new variant or to check whether a flag is still evaluated before archiving ([Evaluation metrics](https://vercel.com/docs/flags/vercel-flags/evaluation-metrics)). Local development evaluates the Development environment configuration.
+- **Archive before delete**: archive after the flag is no longer used in code. Search the code for the key and its camelCase name, remove the declaration and the conditionals, deploy to preview, then `archive`; `unarchive` restores it with configuration and history intact. `rm` requires an archived flag and is permanent ([Clean up after rollout](https://vercel.com/docs/flags/vercel-flags/cli/clean-up-after-rollout), [Archive](https://vercel.com/docs/flags/vercel-flags/dashboard/archive)).
+- **Agent runs**: `archive`, `unarchive`, `rm`, and `update --remove-variant` prompt for confirmation. Pass `--yes` when the user has approved the action.
 
-# Promote to production
-vercel flags enable my-feature --environment production
-
-# Disable in production
-vercel flags disable my-feature --environment production
-
-# Change string variant in production
-vercel flags set my-feature -e production --variant my-variant
-```
-
-`enable` and `disable` only work with boolean flags. For changing the state of other flag types, use the `set` command. Use the vercel-cli skill for full reference.
-
-
-#### Inspect and list flags
-
-```bash
-# Show details of a specific flag (status, environments, targeting rules)
-vercel flags inspect my-feature
-
-# List all flags in the project
-vercel flags list
-```
-
-#### Archive and delete a flag
-
-A flag must be archived before it can be deleted:
-
-```bash
-vercel flags archive my-feature
-vercel flags rm my-feature
-```
-
-#### Manage SDK keys
-
-SDK keys connect your application to Vercel Flags. The `FLAGS` environment variable contains an SDK key.
-
-```bash
-# List SDK keys for the project
-vercel flags sdk-keys ls
-
-# Create a new SDK key
-vercel flags sdk-keys add
-
-# Remove an SDK key
-vercel flags sdk-keys rm <sdk-key-id>
-```
-
-These examples cover common flag operations. For the full `vercel flags` reference and other Vercel CLI commands, see the `vercel-cli` skill. If it isn't installed, suggest the user install it with `npx skills add vercel/vercel@vercel-cli`.
-
-Full CLI reference: https://vercel.com/docs/cli/flags
+CLI reference: https://vercel.com/docs/cli/flags
 
 ---
 
@@ -496,32 +450,6 @@ growthbookAdapter.setTrackingCallback((experiment, result) => {
     console.log('Experiment', experiment.key, 'Variation', result.key);
   });
 });
-```
-
----
-
-## Hypertune
-
-Package: `@flags-sdk/hypertune`
-
-```bash
-pnpm i hypertune flags server-only @flags-sdk/hypertune @vercel/global-config
-```
-
-Requires code generation: `npx hypertune`
-
-```ts
-import { createHypertuneAdapter } from '@flags-sdk/hypertune';
-import { createSource, flagFallbacks, vercelFlagDefinitions, type Context, type FlagValues } from './generated/hypertune';
-
-const hypertuneAdapter = createHypertuneAdapter<FlagValues, Context>({
-  createSource,
-  flagFallbacks,
-  flagDefinitions: vercelFlagDefinitions,
-  identify,
-});
-
-export const exampleFlag = flag(hypertuneAdapter.declarations.exampleFlag);
 ```
 
 ---

--- a/skills/flags-sdk/upstream/SKILL.md
+++ b/skills/flags-sdk/upstream/SKILL.md
@@ -1,27 +1,26 @@
 ---
 name: flags-sdk
 description: >
-  Guide for feature flags and A/B tests with the Flags SDK (`flags` npm package) and Vercel Flags.
-  Use when: declaring flags with `flag()`, using `vercelAdapter` or `vercel flags` CLI
-  (add, list, enable, disable, inspect, archive, rm, sdk-keys),
-  setting up providers/adapters (Vercel, Statsig, LaunchDarkly, PostHog, GrowthBook, Hypertune,
-  Global Config, OpenFeature, Split, Flagsmith, Reflag, Optimizely, or custom adapters),
-  implementing precompute patterns for static pages, setting up `identify`/`dedupe`,
-  integrating Flags Explorer/Toolbar,
-  working with flags in Next.js (App Router, Pages Router, Middleware) or SvelteKit,
-  writing custom adapters, or encrypting/decrypting flag values.
-  Triggers: feature flags, A/B testing, experimentation, flags SDK, flag adapters, precompute,
-  Flags Explorer, feature gates, flag overrides, Vercel Flags, vercel flags CLI, vercel flags add,
-  vercel flags list, vercel flags enable, vercel flags disable,
+  Set up and use feature flags and A/B tests with the Flags SDK (`flags` npm package) and Vercel Flags.
+  Use when installing or configuring the SDK, adding a new or existing flag, wiring `vercelAdapter`
+  (OIDC or SDK keys), declaring flags with `flag()`, using the `vercel flags` CLI (create, inspect, list,
+  enable, disable, set, update, split, rollout, rules, segments, use-targeting, evaluations, versions,
+  open, archive, unarchive, rm, sdk-keys, override, prepare), setting up providers/adapters (Vercel, Statsig, LaunchDarkly,
+  PostHog, GrowthBook, Global Config, OpenFeature, Split, Flagsmith, Reflag, Optimizely, or custom),
+  precompute, `identify`/`dedupe`, Flags Explorer/Toolbar, Next.js or SvelteKit, or encrypting flag values.
+  Triggers: feature flags, feature gates, A/B testing, experimentation, gradual rollout, traffic split,
+  targeting rules, flag overrides, precompute, Flags Explorer, Vercel Flags, vercel flags CLI,
   `flags/next`, `flags/sveltekit`, `flags/react`, `@flags-sdk/*`.
 ---
 
-# Flags SDK
+# Set up and use the Flags SDK
 
 The Flags SDK (`flags` npm package) is a feature flags toolkit for Next.js and SvelteKit. It turns each feature flag into a callable function, works with any flag provider via adapters, and keeps pages static using the precompute pattern. Vercel Flags is the first-party provider, letting you manage flags from the Vercel dashboard or the `vercel flags` CLI.
 
 - Docs: https://flags-sdk.dev
 - Repo: https://github.com/vercel/flags
+
+When the user asks to install, configure, or set up feature flags, follow [Set up the SDK](#set-up-the-sdk) (including `vercel env pull` when `.env.local` is missing). When they ask to create or add a flag, follow [Create a flag](#create-a-flag). Do not leave CLI steps as "next steps" for the user — execute them yourself.
 
 ## Core concepts
 
@@ -60,9 +59,9 @@ export const exampleFlag = flag({
 
 > **Version note**: The SDK is published as `flags` (renamed from `@vercel/flags`; that old name still appears in changelog history). `flags` 4.2.0+ accepts the adapter factory by reference (`adapter: vercelAdapter`) and resolves it once per declaration. Older versions require calling it (`adapter: vercelAdapter()`). The called form still works on new versions, so prefer the shorthand unless you're targeting `flags` < 4.2.0.
 
-## Agent workflow: Creating a new flag
+## Set up the SDK
 
-When a user asks you to create or add a feature flag, follow these steps in order. Do not leave CLI steps as "next steps" for the user — execute them yourself.
+One-time project setup. Run this when the Flags SDK is not installed yet, or when Toolbar / Flags Explorer / `.env.local` are missing. Skip any step that is already done.
 
 ### Before you start
 
@@ -71,10 +70,10 @@ Check the project state to adapt commands and decide which steps you can skip:
 - Which lockfile is present (`pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`, `bun.lockb`)? → Adapt all package manager commands accordingly (`pnpm add`, `npm install`, `yarn add`, `bun add`).
 - Is `flags` in `package.json`? → Skip install (step 1)
 - Does `.vercel/` directory exist? → Project is linked, skip `vercel link` in step 2
-- Does `.env.local` contain `FLAGS=`? → Env vars already pulled, skip step 3
-- Does `flags.ts` (or `lib/flags.ts`, `src/flags.ts`) exist? → Add to it rather than creating from scratch (step 4)
-- Is `@vercel/toolbar` in `package.json`? → Skip toolbar setup (step 6)
-- Does `app/.well-known/vercel/flags/route.ts` exist? → Flags Explorer already set up, skip step 7
+- Does `.env.local` contain `VERCEL_OIDC_TOKEN=` (or a `FLAGS=` SDK key)? → Env vars already pulled, skip step 3
+- Is `@vercel/toolbar` in `package.json`? → Skip toolbar setup (step 4)
+- Does `flags.ts` (or `lib/flags.ts`, `src/flags.ts`) exist? → Skip creating it (step 5)
+- Does `app/.well-known/vercel/flags/route.ts` exist? → Flags Explorer already set up, skip step 6
 
 ### Steps
 
@@ -83,13 +82,52 @@ Check the project state to adapt commands and decide which steps you can skip:
    pnpm i flags @flags-sdk/vercel
    ```
 
-2. **Register the flag with Vercel**: Run `vercel flags add <flag-key> --kind boolean --description "<description>"`.
-
+2. **Link the project to Vercel** (required for `vercel flags` and env vars):
    > **Prerequisite**: The `vercel flags` commands require the Vercel CLI to be installed and authenticated. If the Vercel CLI is not installed, run `pnpm i -g vercel`. For authentication or linking issues, follow the `vercel-cli` skill if it's already available. If it isn't, suggest the user install it with `npx skills add vercel/vercel@vercel-cli` (don't auto-install it) and rely on `vercel <command> --help` in the meantime.
 
-   Before running `vercel flags add`, verify the project is linked to Vercel. Check for a `.vercel` directory in the project root. If it doesn't exist, run `vercel link` first.
+   Check for a `.vercel` directory in the project root. If it doesn't exist, run `vercel link`.
 
-3. **Pull environment variables**: Run `vercel env pull` to write `FLAGS` and `FLAGS_SECRET` to `.env.local`. Without these environment variables, `vercelAdapter` will not be able to evaluate flags. This step is **mandatory** after creating a flag.
+3. **Pull environment variables**: If `.env.local` lacks `VERCEL_OIDC_TOKEN=`, follow [Pull environment variables](#pull-environment-variables).
+
+4. **Set up the Vercel Toolbar** (if not already present):
+   - Run `pnpm i @vercel/toolbar`
+   - Wrap `next.config.ts` with the toolbar plugin
+   - Render `<VercelToolbar />` in the root layout
+   See [references/nextjs.md — Toolbar Setup](references/nextjs.md#toolbar-setup) for the full code.
+
+5. **Ensure `flags.ts` exists**: If missing, create `flags.ts` (or `lib/flags.ts` / `src/flags.ts` to match the project) with `export {}` so TypeScript treats it as a module. Flags Explorer imports this file — create it before the discovery route.
+
+6. **Set up Flags Explorer** (if not already present): Create `app/.well-known/vercel/flags/route.ts` — see [Flags Explorer setup](#flags-explorer-setup). Do this only after `flags.ts` exists. Point the import at the real flags file path (the snippet assumes root `flags.ts`).
+
+## Pull environment variables
+
+`vercel env pull` writes the Development credentials to `.env.local`: the Vercel OIDC token that `vercelAdapter` uses locally (deployments receive it automatically, [Getting started](https://vercel.com/docs/flags/vercel-flags/quickstart#pull-local-openid-connect-credentials)) and the Development `FLAGS_SECRET` for Flags Explorer and overrides. Run it when:
+
+- `.env.local` lacks `VERCEL_OIDC_TOKEN=` (or a `FLAGS=` SDK key)
+- you created the project's first flag; activating Vercel Flags creates a `FLAGS_SECRET` per environment
+- local evaluation fails with an authentication error; the SDK refreshes an expired token through the linked project, re-pulling is the fallback
+
+SDK keys (`FLAGS`) are only for apps outside Vercel, custom environments, or flags of another project ([SDK Keys](https://vercel.com/docs/flags/vercel-flags/dashboard/sdk-keys)). If `FLAGS_SECRET` is still missing after the pull, generate it per [FLAGS_SECRET](#flags_secret).
+
+## Create a flag
+
+When a user asks you to create or add a feature flag that does not exist on Vercel yet, follow these steps in order. If the flag was already created in the dashboard (the prompt says so, or `vercel flags create` reports the key exists), follow [Add a flag that already exists on Vercel](#add-a-flag-that-already-exists-on-vercel) instead.
+
+### Before you start
+
+- Complete [Set up the SDK](#set-up-the-sdk) first if packages, Vercel link, `.env.local`, Toolbar, `flags.ts`, or Flags Explorer are missing. Skip steps that are already done.
+- Does `.env.local` contain `VERCEL_OIDC_TOKEN=`? → Env vars already pulled; see [Pull environment variables](#pull-environment-variables) if local evaluation fails with an authentication error.
+- Does `flags.ts` (or `lib/flags.ts`, `src/flags.ts`) exist? → Add to it rather than creating from scratch.
+
+### Steps
+
+1. **Ensure the SDK is set up**: Follow [Set up the SDK](#set-up-the-sdk) if needed, then continue.
+
+2. **Register the flag with Vercel**: Run `vercel flags create <flag-key> --kind boolean --description "<description>"`.
+
+   Before running `vercel flags create`, verify the project is linked (`.vercel` directory). If missing, run `vercel link` first.
+
+3. **Pull environment variables**: If this is the project's first flag, follow [Pull environment variables](#pull-environment-variables) again; activation created the `FLAGS_SECRET`.
 
 4. **Declare the flag in code**: Add it to `flags.ts` (or create the file if it doesn't exist) using `vercelAdapter`:
    ```ts
@@ -112,25 +150,43 @@ Check the project state to adapt commands and decide which steps you can skip:
    }
    ```
 
-6. **Set up the Vercel Toolbar** (if not already present):
-   - Run `pnpm i @vercel/toolbar`
-   - Wrap `next.config.ts` with the toolbar plugin
-   - Render `<VercelToolbar />` in the root layout
-   See [references/nextjs.md — Toolbar Setup](references/nextjs.md#toolbar-setup) for the full code.
+## Add a flag that already exists on Vercel
 
-7. **Set up Flags Explorer** (if not already present): Create `app/.well-known/vercel/flags/route.ts` — see the [Flags Explorer setup](#flags-explorer-setup) section below.
+Use this flow when the flag was created in the dashboard or by someone else, for example when the prompt says the flag "has already been created" or asks you to run `vercel flags inspect`. Do not run `vercel flags create` for an existing key.
+
+1. **Ensure the SDK is set up**: Follow [Set up the SDK](#set-up-the-sdk) if needed.
+2. **Read the definition**: Run `vercel flags inspect <flag-key>`. Note the kind, the variants (value and label), the description, and what each environment serves.
+3. **Pull environment variables**: If `.env.local` lacks `VERCEL_OIDC_TOKEN=`, follow [Pull environment variables](#pull-environment-variables).
+4. **Declare the flag**: Add it to `flags.ts` with `vercelAdapter`. Map the `inspect` output:
+   - `key`: the flag key exactly as printed
+   - kind → type parameter: `boolean` → `flag<boolean>`, `string` → `flag<string>`, `number` → `flag<number>`, `json` → `flag<YourType>`
+   - `description`: copy from `inspect`
+   - `defaultValue`: the value to serve when the flag is archived or evaluation fails (usually what production serves today)
+   - `options`: optional; mirror the variants when you use precompute or want them listed in Flags Explorer
+   - `identify`: add or reuse one when the flag has targeting, using the entity attributes configured in the dashboard (see [Flag with evaluation context](#flag-with-evaluation-context))
+   ```ts
+   export const welcomeMessage = flag<string>({
+     key: 'welcome-message',
+     description: 'Copy shown on the landing page',
+     defaultValue: 'control',
+     adapter: vercelAdapter,
+   });
+   ```
+5. **Use the flag** as in [Create a flag](#create-a-flag) step 5.
 
 ## Vercel Flags
 
-Vercel Flags is Vercel's feature flags platform. You create and manage flags from the Vercel dashboard or the `vercel flags` CLI, then connect them to your code with the `@flags-sdk/vercel` adapter. When you create a flag in Vercel, the `FLAGS` and `FLAGS_SECRET` environment variables are configured automatically.
+Vercel Flags is Vercel's feature flags platform. You create and manage flags from the Vercel dashboard or the `vercel flags` CLI, then connect them to your code with the `@flags-sdk/vercel` adapter. `vercelAdapter()` authenticates with the project's Vercel OIDC token and evaluates the configuration of the current environment; SDK keys (`FLAGS`) are for manual authentication only ([SDK Keys](https://vercel.com/docs/flags/vercel-flags/dashboard/sdk-keys)). Activating Vercel Flags creates a `FLAGS_SECRET` per environment for Flags Explorer.
 
-To create a flag end-to-end, follow the [Agent workflow](#agent-workflow-creating-a-new-flag) above.
+To install the SDK, follow [Set up the SDK](#set-up-the-sdk). To create a flag end-to-end, follow [Create a flag](#create-a-flag). For a flag that already exists on Vercel, follow [Add a flag that already exists on Vercel](#add-a-flag-that-already-exists-on-vercel).
 
-For the full Vercel provider reference — user targeting, `vercel flags` CLI subcommands, custom adapter configuration, and Flags Explorer setup — see [references/providers.md](references/providers.md#vercel).
+For the full Vercel provider reference — user targeting, how the CLI maps to the SDK (keys, kinds, targeting attributes, SDK keys, overrides, `prepare`), lifecycle and safety, custom adapter configuration, and Flags Explorer setup — see [references/providers.md](references/providers.md#vercel).
+
+For the current `vercel flags` subcommands and options (targeting, splits, rollouts, rules, segments, evaluations, versions, and more), run `vercel flags --help` or `vercel flags <cmd> --help`. For CLI-wide contracts (linking, non-interactive mode, output parsing), use the `vercel-cli` skill.
 
 ## Declaring flags
 
-When using Vercel Flags, declare flags with `vercelAdapter` as shown in the [Agent workflow](#agent-workflow-creating-a-new-flag). For other providers, see [references/providers.md](references/providers.md). Below are the general `flag()` patterns.
+When using Vercel Flags, declare flags with `vercelAdapter` as shown in [Create a flag](#create-a-flag). For other providers, see [references/providers.md](references/providers.md). Below are the general `flag()` patterns.
 
 ### Basic flag
 
@@ -177,6 +233,8 @@ export const dashboardFlag = flag<boolean, Entities>({
   },
 });
 ```
+
+With `vercelAdapter`, the entity and attribute names in the returned object (`user.id` here) are what dashboard rules and `vercel flags split|rollout|rules --by` target. They must match the entities configured in the dashboard. See [references/providers.md — User targeting](references/providers.md#user-targeting).
 
 ### Flag with another adapter
 
@@ -264,7 +322,7 @@ Adapters can opt into batching by implementing the optional `bulkDecide` hook. T
 // app/.well-known/vercel/flags/route.ts
 import { createFlagsDiscoveryEndpoint } from 'flags/next';
 import { getProviderData } from '@flags-sdk/vercel';
-import * as flags from '../../../../flags';
+import * as flags from '../../../../flags'; // adjust if flags live under lib/ or src/
 
 export const GET = createFlagsDiscoveryEndpoint(async () => {
   return getProviderData(flags);
@@ -365,5 +423,5 @@ Detailed framework and provider guides are in separate files to keep context lea
 
 - **[references/nextjs.md](references/nextjs.md)**: Next.js quickstart, toolbar, App Router, Pages Router, middleware/proxy, precompute, dedupe, dashboard pages, marketing pages, suspense fallbacks
 - **[references/sveltekit.md](references/sveltekit.md)**: SvelteKit quickstart, toolbar, hooks setup, precompute with reroute + middleware, dashboard pages, marketing pages
-- **[references/providers.md](references/providers.md)**: All provider adapters — Vercel, Global Config, Statsig, LaunchDarkly, PostHog, GrowthBook, Hypertune, Flagsmith, Reflag, Split, Optimizely, OpenFeature, and custom adapters
+- **[references/providers.md](references/providers.md)**: All provider adapters — Vercel, Global Config, Statsig, LaunchDarkly, PostHog, GrowthBook, Flagsmith, Reflag, Split, Optimizely, OpenFeature, and custom adapters
 - **[references/api.md](references/api.md)**: Full API reference for `flags`, `flags/react`, `flags/next`, and `flags/sveltekit`

--- a/skills/flags-sdk/upstream/references/providers.md
+++ b/skills/flags-sdk/upstream/references/providers.md
@@ -8,7 +8,6 @@
 - [LaunchDarkly](#launchdarkly)
 - [PostHog](#posthog)
 - [GrowthBook](#growthbook)
-- [Hypertune](#hypertune)
 - [Flagsmith](#flagsmith)
 - [Reflag](#reflag)
 - [OpenFeature](#openfeature)
@@ -32,8 +31,8 @@ pnpm i flags @flags-sdk/vercel
 
 Before running any `vercel flags` command, verify the project is linked to Vercel. Check for a `.vercel` directory in the project root. If it doesn't exist, run `vercel link` first.
 
-1. Create a flag in the Vercel dashboard or via CLI: `vercel flags add <flag-key> --kind boolean --description "<description>"`
-2. Pull env vars: you **must** run `vercel env pull` to write `FLAGS` and `FLAGS_SECRET` to `.env.local`. Without these environment variables, `vercelAdapter` will not be able to evaluate flags.
+1. Create a flag in the Vercel dashboard or via CLI: `vercel flags create <flag-key> --kind boolean --description "<description>"`
+2. Pull env vars: run `vercel env pull` to write the Vercel OIDC token and the Development `FLAGS_SECRET` to `.env.local` ([Pull environment variables](../SKILL.md#pull-environment-variables)). See [Authentication](#how-the-cli-connects-to-the-sdk) for SDK keys.
 3. Declare the flag:
 
 ```ts
@@ -69,6 +68,8 @@ export const exampleFlag = flag<boolean, Entities>({
 });
 ```
 
+Define the entities and attributes under Flags → Entities in the dashboard before you use them in rules or segments, and return the same names from `identify` ([Entities](https://vercel.com/docs/flags/vercel-flags/dashboard/entities)). The example above allows `--by user.id` / `--by team.id` in `vercel flags split`, `rollout`, and `rules add`, and the matching conditions in dashboard rules. Entities are evaluated fresh on every call; a rule whose attribute is missing from the context is skipped. See [How the CLI connects to the SDK](#how-the-cli-connects-to-the-sdk).
+
 ### Flags Explorer
 
 ```ts
@@ -102,7 +103,7 @@ If the app also uses `@vercel/flags-core` directly, create the client once and p
 import { createClient } from '@vercel/flags-core';
 import { createVercelAdapter } from '@flags-sdk/vercel';
 
-const vercelFlagsClient = createClient(process.env.FLAGS);
+const vercelFlagsClient = createClient(); // Vercel OIDC token, on deployments and after `vercel env pull`
 const vercelAdapter = createVercelAdapter(vercelFlagsClient);
 
 export const exampleFlag = flag({
@@ -111,84 +112,37 @@ export const exampleFlag = flag({
 });
 ```
 
+Outside Vercel, pass the SDK key: `createClient(process.env.FLAGS)`. Unlike `vercelAdapter()`, `createClient()` does not read `FLAGS` on its own.
+
 ### `vercel flags` CLI
 
-Manage Vercel Flags from the terminal. Requires the [Vercel CLI](https://vercel.com/docs/cli) and a linked project.
+Manage Vercel Flags from the terminal. Install, link, and `vercel env pull` requirements are in [Setup](#setup) above.
 
-> **Prerequisite**: The Vercel CLI must be installed (`pnpm i -g vercel`) and the project must be linked (`vercel link` — check for a `.vercel` directory). For authentication issues, read and follow the `vercel-cli` skill.
+For the current subcommand list and options, run `vercel flags --help` or `vercel flags <cmd> --help`. For CLI-wide contracts (linking, `--non-interactive`, `--yes`, parsing stdout) follow the `vercel-cli` skill. This section covers only what `--help` cannot tell you.
 
-#### Subcommands
+#### How the CLI connects to the SDK
 
-| Subcommand   | Description                                           |
-| ------------ | ----------------------------------------------------- |
-| `list`       | List all flags in the project                         |
-| `add`        | Create a new flag                                     |
-| `inspect`    | Show details, status, and targeting rules of a flag   |
-| `enable`     | Enable a boolean flag for a specific environment      |
-| `disable`    | Disable a boolean flag for a specific environment     |
-| `archive`    | Archive a flag (required before deleting)              |
-| `rm`         | Delete an archived flag                               |
-| `sdk-keys`   | Manage SDK keys (subcommands: `ls`, `add`, `rm`)      |
+- **Key**: the flag slug you pass to the CLI is the `key` in `flag()`. The flag returns one of the variants you created on Vercel ([Run an A/B test](https://vercel.com/docs/flags/vercel-flags/cli/run-ab-test)).
+- **Kind → type**: `inspect <key>` prints the kind and variants. `boolean` → `flag<boolean>()`, `string` → `flag<string>()`, `number` → `flag<number>()`, `json` → `flag<YourType>()`. The kind is fixed at creation and cannot be changed ([Flag types](https://vercel.com/docs/flags/vercel-flags/dashboard/feature-flag#flag-types)).
+- **Variants → `options`**: `options` on the declaration are optional. They give Flags Explorer a dropdown, pre-fill the dashboard when a draft is promoted, and let precompute serialize values and `generatePermutations` enumerate them ([Declaring options](https://vercel.com/docs/flags/vercel-flags/sdks/flags-sdk#declaring-options)). When you declare them, keep them equal to the variants `inspect` shows.
+- **`defaultValue`**: a flag that is archived, or declared in code but not created on Vercel (a draft), evaluates to `defaultValue`. Without `defaultValue`, evaluation throws ([Archive](https://vercel.com/docs/flags/vercel-flags/dashboard/archive#what-happens-when-you-archive), [Drafts](https://vercel.com/docs/flags/vercel-flags/dashboard/drafts#draft-behavior)).
+- **Targeting attributes**: `split`, `rollout`, and `rules add` take `--by <entity>.<attribute>` (and `--condition <entity>.<attribute>:<op>:<value>`). Define the entity and attribute under Flags → Entities first, and return the same names from `identify()`; the docs use a `User` entity with an `id` attribute and `--by user.id` ([Roll out a feature](https://vercel.com/docs/flags/vercel-flags/cli/roll-out-feature), [Entities](https://vercel.com/docs/flags/vercel-flags/dashboard/entities)). When the attribute is missing from the context, a split or rollout serves its fallback variant (`--default-variant` in the CLI) and a rule that references it is skipped. Verify with `evaluations`.
+- **Authentication**: on Vercel, `vercelAdapter()` authenticates with the project's OIDC token and uses the configuration of the current environment; `vercel env pull` brings that credential to `.env.local` for local development. SDK keys (`FLAGS`) are for manual authentication: apps outside Vercel, custom environments, or flags owned by another project. Each SDK key is scoped to one environment and its full value is shown once, at creation ([Getting started](https://vercel.com/docs/flags/vercel-flags/quickstart#pull-local-openid-connect-credentials), [SDK Keys](https://vercel.com/docs/flags/vercel-flags/dashboard/sdk-keys)).
+- **Overrides**: Flags Explorer stores overrides in a cookie signed with `FLAGS_SECRET`; flags declared with the SDK honour it automatically ([Handling overrides](https://vercel.com/docs/flags/flags-explorer/getting-started#handling-overrides)). `vercel flags override <key>=<value>` produces the same token for the `vercel-flag-overrides` cookie and reads `FLAGS_SECRET` from the environment or `.env.local`, so use the secret of the environment you test against (see [FLAGS_SECRET](../SKILL.md#flags_secret)).
+- **Embedded definitions**: Vercel builds fetch the flag definitions once and bundle them into the deployment when the project uses `@flags-sdk/vercel` or `@vercel/flags-core` and the build can authenticate. This keeps every function on one snapshot and serves as the runtime fallback when the service is unreachable; opt out with `VERCEL_FLAGS_DISABLE_DEFINITION_EMBEDDING=1` ([Embedded definitions](https://vercel.com/docs/flags/vercel-flags/sdks/core#embedded-definitions)). `vercel flags prepare` is the same step for builds that run outside Vercel.
 
-#### Create and toggle a flag
+#### Lifecycle and safety
 
-```bash
-# Create a boolean flag with a description
-vercel flags add my-feature --kind boolean --description "New onboarding flow"
+The docs describe these flows end to end: [Roll out a feature](https://vercel.com/docs/flags/vercel-flags/cli/roll-out-feature), [Run an A/B test](https://vercel.com/docs/flags/vercel-flags/cli/run-ab-test), [Clean up after rollout](https://vercel.com/docs/flags/vercel-flags/cli/clean-up-after-rollout). Follow them; the notes below are the parts an agent gets wrong.
 
-# Enable in development first
-vercel flags enable my-feature --environment development
+- **Promote**: deploy the code to preview, `enable` or `set` the flag in preview, verify on the preview URL, deploy to production, then change production (`enable`, `set`, `split`, or `rollout`). Each environment keeps its own configuration; preview stays on its current value until you change it.
+- **Serve vs define**: `enable` / `disable` work on boolean flags only. `set` changes the served variant for any kind. `update` adds, removes, or renames variants and does not change what is served. A variant can only be removed when no environment configuration or rule references it, including rules that are stored but not active ([Deleting a variant](https://vercel.com/docs/flags/vercel-flags/dashboard/feature-flag#deleting-a-variant)).
+- **Static value vs targeting**: `set` / `enable` / `disable` put the environment in static value mode; its split, rollout, and rules are preserved in the background. `use-targeting` switches back to targets and rules mode ([Switching between static and rules modes](https://vercel.com/docs/flags/vercel-flags/dashboard/feature-flag#switching-between-static-and-rules-modes)). Run `inspect` first so you know what the environment serves today.
+- **Confirm a change**: `inspect` for the served state, `versions` for the change history (the dashboard can restore any earlier configuration), `evaluations` to confirm traffic reaches the new variant or to check whether a flag is still evaluated before archiving ([Evaluation metrics](https://vercel.com/docs/flags/vercel-flags/evaluation-metrics)). Local development evaluates the Development environment configuration.
+- **Archive before delete**: archive after the flag is no longer used in code. Search the code for the key and its camelCase name, remove the declaration and the conditionals, deploy to preview, then `archive`; `unarchive` restores it with configuration and history intact. `rm` requires an archived flag and is permanent ([Clean up after rollout](https://vercel.com/docs/flags/vercel-flags/cli/clean-up-after-rollout), [Archive](https://vercel.com/docs/flags/vercel-flags/dashboard/archive)).
+- **Agent runs**: `archive`, `unarchive`, `rm`, and `update --remove-variant` prompt for confirmation. Pass `--yes` when the user has approved the action.
 
-# Promote to production
-vercel flags enable my-feature --environment production
-
-# Disable in production
-vercel flags disable my-feature --environment production
-
-# Change string variant in production
-vercel flags set my-feature -e production --variant my-variant
-```
-
-`enable` and `disable` only work with boolean flags. For changing the state of other flag types, use the `set` command. Use the vercel-cli skill for full reference.
-
-
-#### Inspect and list flags
-
-```bash
-# Show details of a specific flag (status, environments, targeting rules)
-vercel flags inspect my-feature
-
-# List all flags in the project
-vercel flags list
-```
-
-#### Archive and delete a flag
-
-A flag must be archived before it can be deleted:
-
-```bash
-vercel flags archive my-feature
-vercel flags rm my-feature
-```
-
-#### Manage SDK keys
-
-SDK keys connect your application to Vercel Flags. The `FLAGS` environment variable contains an SDK key.
-
-```bash
-# List SDK keys for the project
-vercel flags sdk-keys ls
-
-# Create a new SDK key
-vercel flags sdk-keys add
-
-# Remove an SDK key
-vercel flags sdk-keys rm <sdk-key-id>
-```
-
-These examples cover common flag operations. For the full `vercel flags` reference and other Vercel CLI commands, see the `vercel-cli` skill. If it isn't installed, suggest the user install it with `npx skills add vercel/vercel@vercel-cli`.
-
-Full CLI reference: https://vercel.com/docs/cli/flags
+CLI reference: https://vercel.com/docs/cli/flags
 
 ---
 
@@ -496,32 +450,6 @@ growthbookAdapter.setTrackingCallback((experiment, result) => {
     console.log('Experiment', experiment.key, 'Variation', result.key);
   });
 });
-```
-
----
-
-## Hypertune
-
-Package: `@flags-sdk/hypertune`
-
-```bash
-pnpm i hypertune flags server-only @flags-sdk/hypertune @vercel/global-config
-```
-
-Requires code generation: `npx hypertune`
-
-```ts
-import { createHypertuneAdapter } from '@flags-sdk/hypertune';
-import { createSource, flagFallbacks, vercelFlagDefinitions, type Context, type FlagValues } from './generated/hypertune';
-
-const hypertuneAdapter = createHypertuneAdapter<FlagValues, Context>({
-  createSource,
-  flagFallbacks,
-  flagDefinitions: vercelFlagDefinitions,
-  identify,
-});
-
-export const exampleFlag = flag(hypertuneAdapter.declarations.exampleFlag);
 ```
 
 ---

--- a/skills/vercel-cli/SKILL.md
+++ b/skills/vercel-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vercel-cli
-description: Vercel CLI expert guidance. Use when deploying, managing environment variables, linking projects, viewing logs, querying metrics, managing domains, or interacting with the Vercel platform from the command line.
+description: Vercel CLI expert guidance. Use when deploying, managing environment variables, linking projects, viewing logs, querying metrics, managing domains, managing feature flags with vercel flags, or interacting with the Vercel platform from the command line.
 metadata:
   priority: 4
   docs:
@@ -133,7 +133,7 @@ Use this to route to the correct reference file:
 - **Node.js backends (Express, Hono, etc.)** → `references/node-backends.md`
 - **Monorepos (Turborepo, Nx, workspaces)** → `references/monorepos.md`
 - **Bun runtime** → `references/bun.md`
-- **Feature flags** → `references/flags.md`
+- **Feature flags (`vercel flags`: create, inspect, set, split, rollout, rules, segments, sdk-keys)** → `references/flags.md`
 - **Advanced (API, webhooks)** → `references/advanced.md`
 - **Global flags** → `references/global-options.md`
 - **First-time setup** → `references/getting-started.md`

--- a/skills/vercel-cli/overlay.yaml
+++ b/skills/vercel-cli/overlay.yaml
@@ -1,5 +1,5 @@
 name: vercel-cli
-description: Vercel CLI expert guidance. Use when deploying, managing environment variables, linking projects, viewing logs, querying metrics, managing domains, or interacting with the Vercel platform from the command line.
+description: Vercel CLI expert guidance. Use when deploying, managing environment variables, linking projects, viewing logs, querying metrics, managing domains, managing feature flags with vercel flags, or interacting with the Vercel platform from the command line.
 metadata:
   priority: 4
   docs:

--- a/skills/vercel-cli/references/flags.md
+++ b/skills/vercel-cli/references/flags.md
@@ -1,88 +1,50 @@
 # Feature Flags
 
-`vercel flags` manages [Vercel Flags](https://vercel.com/docs/flags/vercel-flags) — create, inspect, update, set, enable, disable, archive, and delete feature flags, plus manage SDK keys.
+`vercel flags` manages [Vercel Flags](https://vercel.com/docs/flags/vercel-flags) for the linked project.
 
-## Creating Flags
+`--help` is the source of truth for options and examples. Run `vercel flags --help` for the current subcommand list and `vercel flags <cmd> --help` before using a subcommand. The map below routes by task and carries no options on purpose.
 
-`create` is the primary command; `add` is an alias.
-
-```bash
-vercel flags create my-feature                            # create boolean flag
-vercel flags create my-feature --kind string --description "My flag"  # string flag with description
-vercel flags create my-feature --kind string --variant control="Welcome back" --variant treatment="New onboarding"  # with explicit variants
-```
-
-Flag kinds: `boolean` (default), `string`, `number`. Boolean flags get `true`/`false` variants automatically; use `--variant VALUE[=LABEL]` (repeatable) for string/number flags.
-
-## Listing and Inspecting
+## Subcommand Map
 
 ```bash
-vercel flags list                                         # list active flags
-vercel flags list --state archived                        # list archived flags
-vercel flags list --json                                  # output as JSON
-vercel flags inspect my-feature                           # show flag details
+# Read
+vercel flags list                 # flags in the project (alias: ls)
+vercel flags inspect <flag>       # kind, variants, what each environment serves
+vercel flags versions <flag>      # revision history (subcommands: list, diff)
+vercel flags evaluations <flag>   # evaluation metrics
+
+# Change what an environment serves
+vercel flags set <flag>           # serve one variant (all kinds)
+vercel flags enable <flag>        # boolean shortcut for true
+vercel flags disable <flag>       # boolean shortcut for false
+vercel flags use-targeting <flag> # enable targeting for an environment
+
+# Targeting
+vercel flags split <flag>         # weighted traffic split across variants
+vercel flags rollout <flag>       # staged rollout from one variant to another
+vercel flags rules <flag>         # targeting rules (subcommands: list, add, update, remove, move)
+vercel flags segments             # reusable audience segments (subcommands: list, inspect, create, update, remove)
+
+# Lifecycle
+vercel flags create <flag>        # new flag (alias: add)
+vercel flags update <flag>        # variant values and labels
+vercel flags archive <flag>       # required before rm
+vercel flags unarchive <flag>
+vercel flags rm <flag>            # delete an archived flag (alias of remove)
+
+# Tooling
+vercel flags sdk-keys             # SDK keys (subcommands: list, add, remove)
+vercel flags prepare              # flag definition fallbacks for builds outside Vercel
+vercel flags override             # encrypt or decrypt a vercel-flag-overrides cookie token
+vercel flags open [flag]          # open the dashboard
 ```
 
-## Opening in Dashboard
+## CLI Contracts
 
-```bash
-vercel flags open                                         # open project flags dashboard
-vercel flags open my-feature                              # open a specific flag
-```
+- Flags commands need a linked project. Confirm the target with `vercel project inspect --non-interactive` first (see `SKILL.md`).
+- Use `--json` where a subcommand offers it and parse only stdout.
+- Commands that ask for confirmation (`archive`, `unarchive`, `rm`, `sdk-keys rm`, and others that list `--yes` in `--help`) need `--yes` in non-interactive runs.
 
-## Updating Flags
+## Flags SDK Skill
 
-Update variant values, labels, or both on an existing flag.
-
-```bash
-vercel flags update my-feature --variant control --value welcome-back --label "Welcome back"
-vercel flags update my-feature --variant control --label "Control" --message "Rename control variant"
-vercel flags update my-feature --variant false --label "Disabled"
-```
-
-Options: `--variant` (variant ID or value), `--value` (new value), `--label`/`-l` (new label), `--message` (revision message).
-
-## Setting Served Variant
-
-`set` controls which variant is served in a given environment. Works with all flag kinds.
-
-```bash
-vercel flags set welcome-message -e production --variant control
-vercel flags set bucket-size -e preview --variant 20
-vercel flags set my-feature -e development --variant true
-```
-
-Options: `--environment`/`-e`, `--variant`/`-v`, `--message`.
-
-## Enable / Disable (Boolean Shortcut)
-
-Only works with **boolean** flags. Shortcuts that set the served variant to `true` or `false`.
-
-```bash
-vercel flags enable my-feature -e production
-vercel flags enable my-feature -e production --message "Resume production rollout"
-vercel flags disable my-feature -e production
-vercel flags disable my-feature -e production --variant off
-vercel flags disable my-feature -e production --message "Pause rollout"
-```
-
-Environments: `production`, `preview`, `development`. Omit `-e` to choose interactively.
-
-## Archive / Delete
-
-```bash
-vercel flags archive my-feature --yes                     # archive (skip prompt)
-vercel flags rm my-feature --yes                          # delete (must be archived first)
-```
-
-## SDK Keys
-
-SDK keys authenticate your application when evaluating flags. The full key value is only shown at creation time.
-
-```bash
-vercel flags sdk-keys ls                                  # list SDK keys
-vercel flags sdk-keys ls --json                           # list as JSON
-vercel flags sdk-keys add --type server -e production     # create server key
-vercel flags sdk-keys add --type client -e preview --label "Preview App"  # client key with label
-vercel flags sdk-keys rm <hash-key> --yes                 # delete key
-```
+Everything flags-specific lives in the `flags-sdk` skill (`npx skills add vercel/flags@flags-sdk`): declaring flags with `flag()` and `vercelAdapter`, matching a CLI flag key to the `key` in code, `identify()` entities and the `--by` / `--condition` attribute contract, adopting a flag that already exists (`inspect` first), lifecycle and production safety, `FLAGS` / `FLAGS_SECRET`, `prepare`, and `override`. Use that skill for those topics; this reference does not repeat them.

--- a/skills/vercel-cli/references/flags.md
+++ b/skills/vercel-cli/references/flags.md
@@ -24,6 +24,7 @@ vercel flags split <flag>         # weighted traffic split across variants
 vercel flags rollout <flag>       # staged rollout from one variant to another
 vercel flags rules <flag>         # targeting rules (subcommands: list, add, update, remove, move)
 vercel flags segments             # reusable audience segments (subcommands: list, inspect, create, update, remove)
+vercel flags entities             # entity schemas for targeting (subcommands: ls, create, update, rm)
 
 # Lifecycle
 vercel flags create <flag>        # new flag (alias: add)

--- a/skills/vercel-cli/upstream/SKILL.md
+++ b/skills/vercel-cli/upstream/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vercel-cli
-description: Deploy, manage, and develop projects on Vercel from the command line
+description: Deploy, manage, and develop projects on Vercel from the command line, including feature flags (`vercel flags`).
 ---
 
 # Vercel CLI Skill
@@ -50,7 +50,7 @@ Use this to route to the correct reference file:
 - **Node.js backends (Express, Hono, etc.)** → `references/node-backends.md`
 - **Monorepos (Turborepo, Nx, workspaces)** → `references/monorepos.md`
 - **Bun runtime** → `references/bun.md`
-- **Feature flags** → `references/flags.md`
+- **Feature flags (`vercel flags`: create, inspect, set, split, rollout, rules, segments, sdk-keys)** → `references/flags.md`
 - **Advanced (API, webhooks)** → `references/advanced.md`
 - **Global flags** → `references/global-options.md`
 - **First-time setup** → `references/getting-started.md`

--- a/skills/vercel-cli/upstream/references/flags.md
+++ b/skills/vercel-cli/upstream/references/flags.md
@@ -1,88 +1,50 @@
 # Feature Flags
 
-`vercel flags` manages [Vercel Flags](https://vercel.com/docs/flags/vercel-flags) — create, inspect, update, set, enable, disable, archive, and delete feature flags, plus manage SDK keys.
+`vercel flags` manages [Vercel Flags](https://vercel.com/docs/flags/vercel-flags) for the linked project.
 
-## Creating Flags
+`--help` is the source of truth for options and examples. Run `vercel flags --help` for the current subcommand list and `vercel flags <cmd> --help` before using a subcommand. The map below routes by task and carries no options on purpose.
 
-`create` is the primary command; `add` is an alias.
-
-```bash
-vercel flags create my-feature                            # create boolean flag
-vercel flags create my-feature --kind string --description "My flag"  # string flag with description
-vercel flags create my-feature --kind string --variant control="Welcome back" --variant treatment="New onboarding"  # with explicit variants
-```
-
-Flag kinds: `boolean` (default), `string`, `number`. Boolean flags get `true`/`false` variants automatically; use `--variant VALUE[=LABEL]` (repeatable) for string/number flags.
-
-## Listing and Inspecting
+## Subcommand Map
 
 ```bash
-vercel flags list                                         # list active flags
-vercel flags list --state archived                        # list archived flags
-vercel flags list --json                                  # output as JSON
-vercel flags inspect my-feature                           # show flag details
+# Read
+vercel flags list                 # flags in the project (alias: ls)
+vercel flags inspect <flag>       # kind, variants, what each environment serves
+vercel flags versions <flag>      # revision history (subcommands: list, diff)
+vercel flags evaluations <flag>   # evaluation metrics
+
+# Change what an environment serves
+vercel flags set <flag>           # serve one variant (all kinds)
+vercel flags enable <flag>        # boolean shortcut for true
+vercel flags disable <flag>       # boolean shortcut for false
+vercel flags use-targeting <flag> # enable targeting for an environment
+
+# Targeting
+vercel flags split <flag>         # weighted traffic split across variants
+vercel flags rollout <flag>       # staged rollout from one variant to another
+vercel flags rules <flag>         # targeting rules (subcommands: list, add, update, remove, move)
+vercel flags segments             # reusable audience segments (subcommands: list, inspect, create, update, remove)
+
+# Lifecycle
+vercel flags create <flag>        # new flag (alias: add)
+vercel flags update <flag>        # variant values and labels
+vercel flags archive <flag>       # required before rm
+vercel flags unarchive <flag>
+vercel flags rm <flag>            # delete an archived flag (alias of remove)
+
+# Tooling
+vercel flags sdk-keys             # SDK keys (subcommands: list, add, remove)
+vercel flags prepare              # flag definition fallbacks for builds outside Vercel
+vercel flags override             # encrypt or decrypt a vercel-flag-overrides cookie token
+vercel flags open [flag]          # open the dashboard
 ```
 
-## Opening in Dashboard
+## CLI Contracts
 
-```bash
-vercel flags open                                         # open project flags dashboard
-vercel flags open my-feature                              # open a specific flag
-```
+- Flags commands need a linked project. Confirm the target with `vercel project inspect --non-interactive` first (see `SKILL.md`).
+- Use `--json` where a subcommand offers it and parse only stdout.
+- Commands that ask for confirmation (`archive`, `unarchive`, `rm`, `sdk-keys rm`, and others that list `--yes` in `--help`) need `--yes` in non-interactive runs.
 
-## Updating Flags
+## Flags SDK Skill
 
-Update variant values, labels, or both on an existing flag.
-
-```bash
-vercel flags update my-feature --variant control --value welcome-back --label "Welcome back"
-vercel flags update my-feature --variant control --label "Control" --message "Rename control variant"
-vercel flags update my-feature --variant false --label "Disabled"
-```
-
-Options: `--variant` (variant ID or value), `--value` (new value), `--label`/`-l` (new label), `--message` (revision message).
-
-## Setting Served Variant
-
-`set` controls which variant is served in a given environment. Works with all flag kinds.
-
-```bash
-vercel flags set welcome-message -e production --variant control
-vercel flags set bucket-size -e preview --variant 20
-vercel flags set my-feature -e development --variant true
-```
-
-Options: `--environment`/`-e`, `--variant`/`-v`, `--message`.
-
-## Enable / Disable (Boolean Shortcut)
-
-Only works with **boolean** flags. Shortcuts that set the served variant to `true` or `false`.
-
-```bash
-vercel flags enable my-feature -e production
-vercel flags enable my-feature -e production --message "Resume production rollout"
-vercel flags disable my-feature -e production
-vercel flags disable my-feature -e production --variant off
-vercel flags disable my-feature -e production --message "Pause rollout"
-```
-
-Environments: `production`, `preview`, `development`. Omit `-e` to choose interactively.
-
-## Archive / Delete
-
-```bash
-vercel flags archive my-feature --yes                     # archive (skip prompt)
-vercel flags rm my-feature --yes                          # delete (must be archived first)
-```
-
-## SDK Keys
-
-SDK keys authenticate your application when evaluating flags. The full key value is only shown at creation time.
-
-```bash
-vercel flags sdk-keys ls                                  # list SDK keys
-vercel flags sdk-keys ls --json                           # list as JSON
-vercel flags sdk-keys add --type server -e production     # create server key
-vercel flags sdk-keys add --type client -e preview --label "Preview App"  # client key with label
-vercel flags sdk-keys rm <hash-key> --yes                 # delete key
-```
+Everything flags-specific lives in the `flags-sdk` skill (`npx skills add vercel/flags@flags-sdk`): declaring flags with `flag()` and `vercelAdapter`, matching a CLI flag key to the `key` in code, `identify()` entities and the `--by` / `--condition` attribute contract, adopting a flag that already exists (`inspect` first), lifecycle and production safety, `FLAGS` / `FLAGS_SECRET`, `prepare`, and `override`. Use that skill for those topics; this reference does not repeat them.

--- a/skills/vercel-cli/upstream/references/flags.md
+++ b/skills/vercel-cli/upstream/references/flags.md
@@ -24,6 +24,7 @@ vercel flags split <flag>         # weighted traffic split across variants
 vercel flags rollout <flag>       # staged rollout from one variant to another
 vercel flags rules <flag>         # targeting rules (subcommands: list, add, update, remove, move)
 vercel flags segments             # reusable audience segments (subcommands: list, inspect, create, update, remove)
+vercel flags entities             # entity schemas for targeting (subcommands: ls, create, update, rm)
 
 # Lifecycle
 vercel flags create <flag>        # new flag (alias: add)


### PR DESCRIPTION
Flags & CLI skills have updated and diverged from the bundled skills in this repo. Updating the flags guidance here too.

Syncs `flags-sdk` from [vercel/flags#492](https://github.com/vercel/flags/pull/492) and applies only the flags reference and discovery changes to the existing CLI skill.

Validation: build, typecheck, skill validation, generated-file checks, and all 992 tests pass (`bun test --timeout 20000`).

Closes [EXP-3444](https://linear.app/vercel/issue/EXP-3444). Related: [EXP-3411](https://linear.app/vercel/issue/EXP-3411), [EXP-3424](https://linear.app/vercel/issue/EXP-3424).
