### PR TITLE
Test all skill frontmatter with a standard YAML parser

### DIFF
--- a/tests/skill-map-frontmatter.test.ts
+++ b/tests/skill-map-frontmatter.test.ts
@@ -36,6 +36,25 @@ function countSkillDirs(): number {
   }).length;
 }
 
+describe("skill frontmatter portability", () => {
+  test("all skill frontmatter is valid standard YAML", () => {
+    const invalidSkills: string[] = [];
+
+    for (const skillDir of readdirSync(SKILLS_DIR)) {
+      const skillPath = join(SKILLS_DIR, skillDir, "SKILL.md");
+      if (!existsSync(skillPath)) continue;
+
+      try {
+        Bun.YAML.parse(readSkillFrontmatter(skillDir));
+      } catch (error) {
+        invalidSkills.push(`${skillDir}: ${String(error)}`);
+      }
+    }
+
+    expect(invalidSkills).toEqual([]);
+  });
+});
+
 // ─── Migration regression: skill-map.json must not exist ─────────
 
 describe("migration regression", () => {


### PR DESCRIPTION
## Summary

#174 fixed the invalid AI Gateway YAML. This follow-up retains the regression coverage: every `SKILL.md` frontmatter block is parsed with Bun's standards-compliant YAML parser, so malformed frontmatter cannot silently remove a skill from discovery again.

Follow-up to #172 and #174.

## Validation

- `bun run validate`
- `bun test` — 993 passed, 0 failed
- `bun run typecheck`
