### PR TITLE
Fix AI Gateway skill YAML parsing

### DIFF
--- a/generated/skill-manifest.json
+++ b/generated/skill-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-31T23:43:50.786Z",
+  "generatedAt": "2026-09-08T06:36:27.856Z",
   "version": 2,
   "skills": {
     "access-protected-vercel-deployment": {
@@ -184,7 +184,7 @@
       ],
       "chainTo": [
         {
-          "pattern": "from\\s+[''\"]ai[''\"]|require\\([''\"]ai[''']\\)|\\b(generateText|streamText|ToolLoopAgent)\\b",
+          "pattern": "from\\s+[''\"]ai[''\"]|require\\([''\"]ai[''\"]\\)|\\b(generateText|streamText|ToolLoopAgent)\\b",
           "targetSkill": "ai-sdk",
           "message": "AI SDK code detected. Load the AI SDK skill and read the installed package docs before writing or changing SDK code."
         }

--- a/skills/ai-gateway/SKILL.md
+++ b/skills/ai-gateway/SKILL.md
@@ -73,7 +73,7 @@ validate:
     skipIfFileContains: 'ANTHROPIC_AUTH_TOKEN'
 chainTo:
   -
-    pattern: 'from\s+[''"]ai[''"]|require\([''"]ai[''']\)|\b(generateText|streamText|ToolLoopAgent)\b'
+    pattern: 'from\s+[''"]ai[''"]|require\([''"]ai[''"]\)|\b(generateText|streamText|ToolLoopAgent)\b'
     targetSkill: ai-sdk
     message: 'AI SDK code detected. Load the AI SDK skill and read the installed package docs before writing or changing SDK code.'
 retrieval:


### PR DESCRIPTION
## Summary

- Fix the malformed quote in the AI Gateway skill's `chainTo` regex
- Regenerate the skill manifest with the corrected pattern
- Restore fresh installation through `pnpx skills add vercel/vercel-plugin --skill ai-gateway`

## Validation

- Reproduced the installer failure from `main`: `Unexpected flow-seq-end token in YAML stream`
- `bun run validate`
- `bun test tests/skill-map-frontmatter.test.ts tests/validate.test.ts` (142 passed)
- `bun run build:manifest:check`
- Clean project-local install with `pnpx skills add /tmp/vercel-plugin-skill-source --skill ai-gateway --agent codex -y --copy`
